### PR TITLE
test: exercise Postgres RLS in suites and add cross-tenant isolation tests

### DIFF
--- a/apps/billing/service/business/tenant_isolation_test.go
+++ b/apps/billing/service/business/tenant_isolation_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business_test
+
+import (
+	"testing"
+
+	"github.com/antinvestor/service-payments/apps/billing/service/models"
+	"github.com/antinvestor/service-payments/apps/billing/tests"
+	_ "github.com/lib/pq"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type TenantIsolationSuite struct {
+	tests.BaseTestSuite
+}
+
+func TestTenantIsolationSuite(t *testing.T) {
+	suite.Run(t, new(TenantIsolationSuite))
+}
+
+// TestSubscriptionTenantIsolation verifies Postgres RLS hides one
+// tenant's subscriptions from another tenant. The suite drops
+// application queries to an unprivileged role, so the tenancy
+// policies installed during migration are actually enforced.
+func (ts *TenantIsolationSuite) TestSubscriptionTenantIsolation() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		subBus := resources.SubscriptionBusiness
+
+		ctxA := ts.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := ts.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		profileID := util.IDString()
+		sub, err := subBus.CreateSubscription(ctxA, &models.Subscription{
+			ProfileID:        profileID,
+			PlanID:           util.IDString(),
+			CatalogVersionID: util.IDString(),
+			Currency:         "KES",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "tenant-a", sub.TenantID)
+
+		// Owning tenant reads its subscription back.
+		got, err := subBus.GetSubscription(ctxA, sub.ID)
+		require.NoError(t, err)
+		require.Equal(t, sub.ID, got.ID)
+
+		// Another tenant must not be able to read it.
+		_, err = subBus.GetSubscription(ctxB, sub.ID)
+		require.Error(t, err, "tenant B must not read tenant A's subscription")
+
+		// Even for the same profile, listings stay within the tenant.
+		list, err := subBus.ListActiveByProfile(ctxB, profileID)
+		require.NoError(t, err)
+		require.Empty(t, list, "tenant B must not list tenant A's subscriptions")
+	})
+}

--- a/apps/billing/tests/base_testsuite.go
+++ b/apps/billing/tests/base_testsuite.go
@@ -25,6 +25,7 @@ import (
 	// Ledger integration.
 	ledgerBusiness "github.com/antinvestor/service-payments/apps/ledger/service/business"
 	ledgerRepo "github.com/antinvestor/service-payments/apps/ledger/service/repository"
+	"github.com/antinvestor/service-payments/internal/rlsadmin"
 
 	// Register PostgreSQL driver for database connections.
 	_ "github.com/lib/pq"
@@ -34,6 +35,8 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
+	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
 )
@@ -111,12 +114,20 @@ func (bs *BaseTestSuite) CreateService(
 	cfg.DatabasePrimaryURL = []string{testDS.String()}
 	cfg.DatabaseReplicaURL = []string{testDS.String()}
 
+	// Drop application queries to an unprivileged role so Postgres RLS
+	// is actually enforced (the testcontainer user is a superuser which
+	// bypasses FORCE ROW LEVEL SECURITY).
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	frameOpts = append(
 		[]frame.Option{
 			frame.WithName("billing tests"), frame.WithConfig(&cfg),
+			frame.WithTenancyProvider(rlsProv),
 			frame.WithDatastore(), frametests.WithNoopDriver()}, frameOpts...)
 
 	ctx, svc := frame.NewServiceWithContext(ctx, frameOpts...)
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	dbManager := svc.DatastoreManager()
 	dbPool := dbManager.GetPool(ctx, datastore.DefaultPoolName)
@@ -181,6 +192,10 @@ func (bs *BaseTestSuite) CreateService(
 	err = repository.Migrate(ctx, dbManager, "../../billing/migrations/0001")
 	require.NoError(t, err)
 
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
+
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)
 
@@ -204,4 +219,18 @@ func (bs *BaseTestSuite) WithTestDependencies(
 	}
 
 	frametests.WithTestDependencies(t, options, testFn)
+}
+
+// WithAuthClaims creates a context with authentication claims for the given tenant, partition, and profile.
+func (bs *BaseTestSuite) WithAuthClaims(ctx context.Context, tenantID, partitionID, profileID string) context.Context {
+	claims := &security.AuthenticationClaims{
+		TenantID:    tenantID,
+		PartitionID: partitionID,
+		AccessID:    util.IDString(),
+		ContactID:   profileID,
+		SessionID:   util.IDString(),
+		DeviceID:    "test-device",
+	}
+	claims.Subject = profileID
+	return claims.ClaimsToContext(ctx)
 }

--- a/apps/ledger/service/repository/tenant_isolation_test.go
+++ b/apps/ledger/service/repository/tenant_isolation_test.go
@@ -1,0 +1,117 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	models "github.com/antinvestor/service-payments/apps/ledger/service/models"
+	"github.com/antinvestor/service-payments/apps/ledger/service/repository"
+	_ "github.com/lib/pq"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerTenantIsolation verifies Postgres RLS hides one tenant's
+// ledgers from another tenant. The suite drops application queries to
+// an unprivileged role, so the tenancy policies installed during
+// migration are actually enforced.
+func (ls *LedgersSuite) TestLedgerTenantIsolation() {
+	ls.WithTestDependencies(ls.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ls.CreateService(t, dep)
+
+		ledgerRepo := resources.LedgerRepository
+
+		ctxA := ls.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := ls.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		lg := &models.Ledger{Type: models.LedgerTypeAsset}
+		require.NoError(t, ledgerRepo.Create(ctxA, lg))
+		require.Equal(t, "tenant-a", lg.TenantID)
+
+		// Owning tenant reads its ledger back.
+		got, err := ledgerRepo.GetByID(ctxA, lg.ID)
+		require.NoError(t, err)
+		require.Equal(t, lg.ID, got.ID)
+
+		// Another tenant must not be able to read it.
+		_, err = ledgerRepo.GetByID(ctxB, lg.ID)
+		require.Error(t, err, "tenant B must not read tenant A's ledger")
+
+		// Cross-tenant search must come back empty.
+		require.Empty(t, collectLedgers(ctxB, t, ledgerRepo),
+			"tenant B search must not return tenant A's ledgers")
+	})
+}
+
+// TestAccountTenantIsolation verifies accounts are isolated per tenant.
+func (ls *LedgersSuite) TestAccountTenantIsolation() {
+	ls.WithTestDependencies(ls.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ls.CreateService(t, dep)
+
+		ledgerRepo := resources.LedgerRepository
+		accountRepo := resources.AccountRepository
+
+		ctxA := ls.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := ls.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		lg := &models.Ledger{Type: models.LedgerTypeAsset}
+		require.NoError(t, ledgerRepo.Create(ctxA, lg))
+
+		acc := &models.Account{
+			Currency:   "KES",
+			LedgerID:   lg.ID,
+			LedgerType: models.LedgerTypeAsset,
+		}
+		require.NoError(t, accountRepo.Create(ctxA, acc))
+
+		// Owning tenant reads its account back.
+		got, err := accountRepo.GetByID(ctxA, acc.ID)
+		require.NoError(t, err)
+		require.Equal(t, acc.ID, got.ID)
+
+		// Another tenant must not be able to read it. GetByID's contract
+		// is (nil, nil) when no row is visible.
+		invisible, err := accountRepo.GetByID(ctxB, acc.ID)
+		require.NoError(t, err)
+		require.Nil(t, invisible, "tenant B must not read tenant A's account")
+
+		listed, err := accountRepo.ListByID(ctxB, acc.ID)
+		require.NoError(t, err)
+		require.Empty(t, listed, "tenant B must not list tenant A's accounts")
+	})
+}
+
+func collectLedgers(ctx context.Context, t *testing.T, repo repository.LedgerRepository) []*models.Ledger {
+	t.Helper()
+
+	result, err := repo.SearchAsESQ(ctx, "{}")
+	require.NoError(t, err)
+
+	var all []*models.Ledger
+	for {
+		res, ok := result.ReadResult(ctx)
+		if !ok {
+			break
+		}
+		if res.IsError() {
+			t.Fatalf("unexpected search error: %v", res.Error())
+		}
+		all = append(all, res.Item()...)
+	}
+	return all
+}

--- a/apps/ledger/tests/base_testsuite.go
+++ b/apps/ledger/tests/base_testsuite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/antinvestor/service-payments/apps/ledger/service/business"
 	"github.com/antinvestor/service-payments/apps/ledger/service/repository"
 	"github.com/antinvestor/service-payments/apps/ledger/tests/testketo"
+	"github.com/antinvestor/service-payments/internal/rlsadmin"
 
 	// Register PostgreSQL driver for database connections.
 	_ "github.com/lib/pq"
@@ -34,6 +35,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
@@ -137,12 +139,20 @@ func (bs *BaseTestSuite) CreateService(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// Drop application queries to an unprivileged role so Postgres RLS
+	// is actually enforced (the testcontainer user is a superuser which
+	// bypasses FORCE ROW LEVEL SECURITY).
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	frameOpts = append(
 		[]frame.Option{
 			frame.WithName("ledger tests"), frame.WithConfig(&cfg),
+			frame.WithTenancyProvider(rlsProv),
 			frame.WithDatastore(), frametests.WithNoopDriver()}, frameOpts...)
 
 	ctx, svc := frame.NewServiceWithContext(ctx, frameOpts...)
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	dbManager := svc.DatastoreManager()
 	dbPool := dbManager.GetPool(ctx, datastore.DefaultPoolName)
@@ -174,6 +184,10 @@ func (bs *BaseTestSuite) CreateService(
 
 	err = repository.Migrate(ctx, dbManager, "../../migrations/0001")
 	require.NoError(t, err)
+
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,10 @@ require (
 	connectrpc.com/otelconnect v0.9.0
 	github.com/antinvestor/common v1.5.0
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/moby/moby/api v1.54.2
-	github.com/pitabwire/frame v1.98.1
+	github.com/pitabwire/frame v1.98.2
 	github.com/pitabwire/util v0.9.1
 	github.com/pitabwire/util/decimalx v0.7.2
 	github.com/pitabwire/util/moneyx v0.9.0
@@ -76,7 +77,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.1 h1:MdHUk9ux0XTgrerATnpQ5nC3iT0v7MXFEbChQ91/FEc=
-github.com/pitabwire/frame v1.98.1/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
+github.com/pitabwire/frame v1.98.2 h1:Kv/9w4+P/2En9hGBrXawNPOk0DMwek8HUg0A21WMnu8=
+github.com/pitabwire/frame v1.98.2/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=

--- a/internal/rlsadmin/rlsadmin.go
+++ b/internal/rlsadmin/rlsadmin.go
@@ -1,0 +1,81 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rlsadmin complements frame's frametests/rlstest helper for
+// test suites whose tests legitimately run DDL under the unprivileged
+// RLS role — re-running migrations, partition retention maintenance or
+// fault-injection ALTERs. Plain table privileges (rlstest.GrantAll) are
+// not enough for those: Postgres requires table ownership for DDL.
+//
+// Transferring ownership to the test role is safe for the isolation
+// guarantees because frame installs its tenancy policies with FORCE
+// ROW LEVEL SECURITY, which applies RLS to the table owner as well.
+package rlsadmin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pitabwire/frame/frametests/rlstest"
+
+	// Pull in the pgx stdlib driver so database/sql can dial postgres.
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// GrantOwnership makes the rlstest role the owner of every table,
+// sequence and non-extension function in the public schema and allows
+// it to create new relations. Function ownership is needed because
+// re-running migrations re-issues CREATE OR REPLACE FUNCTION for
+// frame's app_tenancy_matches helper. Must be invoked AFTER migration
+// (alongside rlstest.GrantAll) so all objects exist. Idempotent.
+func GrantOwnership(ctx context.Context, dsn string) error {
+	adminDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("rlsadmin: open admin db: %w", err)
+	}
+	defer adminDB.Close()
+
+	stmts := []string{
+		`GRANT CREATE ON SCHEMA public TO ` + rlstest.Role,
+		`DO $$
+		DECLARE r record;
+		BEGIN
+			FOR r IN SELECT tablename AS name FROM pg_tables WHERE schemaname = 'public' LOOP
+				EXECUTE format('ALTER TABLE public.%I OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+			FOR r IN SELECT sequencename AS name FROM pg_sequences WHERE schemaname = 'public' LOOP
+				EXECUTE format('ALTER SEQUENCE public.%I OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+			FOR r IN
+				SELECT p.oid::regprocedure AS name
+				FROM pg_proc p
+				JOIN pg_namespace n ON p.pronamespace = n.oid
+				WHERE n.nspname = 'public'
+				AND NOT EXISTS (
+					SELECT 1 FROM pg_depend d
+					WHERE d.objid = p.oid AND d.deptype = 'e'
+				)
+			LOOP
+				EXECUTE format('ALTER FUNCTION %s OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+		END $$`,
+	}
+	for _, stmt := range stmts {
+		if _, err = adminDB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("rlsadmin: %s: %w", stmt, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

frame ≥v1.95 installs tenant-isolation RLS policies during `pool.Migrate`, but our suites ran every query as the testcontainer **superuser**, which bypasses `FORCE ROW LEVEL SECURITY` — so isolation was never actually exercised. This PR wires frame v1.98.2's `frametests/rlstest` into the ledger and billing base test suites so application queries run under an unprivileged role, and adds genuine cross-tenant isolation tests.

### Wiring (apps/ledger and apps/billing `tests/base_testsuite.go`)
- `rlstest.CreateRole` before service init, `frame.WithTenancyProvider(rlstest.New())` on the service, `rlstest.GrantAll` + `rlsadmin.GrantOwnership` after migration, then `Enable()` — mirroring the working pattern in service-fintech.
- New `internal/rlsadmin` helper transfers table/sequence/function ownership to the test role so tests that legitimately re-run migrations keep working under the dropped role (`CREATE OR REPLACE FUNCTION app_tenancy_matches` requires function ownership). `FORCE RLS` applies to the owner too, so isolation stays enforced.
- Test services are now stopped via `t.Cleanup`, fixing a **pre-existing** connection-exhaustion flake (`FATAL: sorry, too many clients already`) reproducible on main.
- Added a `WithAuthClaims` helper to the billing base suite (mirrors ledger's).

### New isolation tests
- `apps/ledger/service/repository/tenant_isolation_test.go`: ledgers and accounts created by tenant A are invisible to tenant B (`GetByID`, `SearchAsESQ`, `ListByID`). Note: `AccountRepository.GetByID` intentionally returns `(nil, nil)` for rows that aren't visible — business callers map that to `ErrAccountNotFound` — so the account test asserts the nil contract.
- `apps/billing/service/business/tenant_isolation_test.go`: subscriptions created by tenant A are invisible to tenant B (`GetSubscription`, `ListActiveByProfile` for the same profile ID).

No production tenancy bugs found in this repo — all ledger/billing models are registered as pointers and enrol correctly.

## Testing
- `go test ./... -count=1`: all packages pass (ledger business needs ~2 min; the suite-level 10m default is only at risk when running many repos concurrently).
- `golangci-lint run` on changed packages: 0 issues; `go build ./...` clean.