### PR TITLE
feat(metrics): tenant-scoped business metrics for the payment lifecycle

### DIFF
--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -151,7 +151,7 @@ func main() { //nolint:funlen // service wiring requires sequential setup
 			events.NewPaymentLinkSave(paymentLinkRepo),
 			events.NewAccountSave(accountRepo),
 			events.NewCostSave(costRepo),
-			events.NewStatusSave(statusRepo),
+			events.NewStatusSave(statusRepo, paymentRepo),
 		))
 
 	// Initialize the service with all options

--- a/apps/default/service/business/payments.go
+++ b/apps/default/service/business/payments.go
@@ -30,6 +30,7 @@ import (
 	"buf.build/gen/go/antinvestor/tenancy/connectrpc/go/tenancy/v1/tenancyv1connect"
 	"connectrpc.com/connect"
 	"github.com/antinvestor/service-payments/apps/default/service/events"
+	"github.com/antinvestor/service-payments/apps/default/service/metrics"
 	"github.com/antinvestor/service-payments/apps/default/service/models"
 	"github.com/antinvestor/service-payments/apps/default/service/repository"
 	"github.com/pitabwire/frame/data"
@@ -73,6 +74,7 @@ func NewPaymentBusiness(
 		promptRepo:           promptRepo,
 		paymentLinkRepo:      paymentLinkRepo,
 		workMan:              workMan,
+		paymentMetrics:       metrics.NewPaymentMetrics(),
 	}, nil
 }
 
@@ -91,6 +93,7 @@ type paymentBusiness struct {
 	promptRepo           repository.PromptRepository
 	paymentLinkRepo      repository.PaymentLinkRepository
 	workMan              workerpool.Manager
+	paymentMetrics       *metrics.PaymentMetrics
 }
 
 func (pb *paymentBusiness) Send(ctx context.Context, message *paymentv1.Payment) (*commonv1.StatusResponse, error) {
@@ -180,6 +183,8 @@ func (pb *paymentBusiness) Send(ctx context.Context, message *paymentv1.Payment)
 		util.Log(ctx).WithError(err).Warn("could not save status")
 		return nil, err
 	}
+
+	pb.paymentMetrics.RecordInitiated(ctx, p)
 
 	return status.ToAPI(), nil
 }
@@ -271,6 +276,8 @@ func (pb *paymentBusiness) Receive(ctx context.Context, message *paymentv1.Payme
 		util.Log(ctx).WithError(err).Warn("could not emit status event")
 		return nil, err
 	}
+
+	pb.paymentMetrics.RecordInitiated(ctx, p)
 
 	return status.ToAPI(), nil
 }

--- a/apps/default/service/events/status_save.go
+++ b/apps/default/service/events/status_save.go
@@ -18,20 +18,30 @@ import (
 	"context"
 	"errors"
 
+	"github.com/antinvestor/service-payments/apps/default/service/metrics"
 	"github.com/antinvestor/service-payments/apps/default/service/models"
 	"github.com/antinvestor/service-payments/apps/default/service/repository"
 	"github.com/pitabwire/frame/data"
 	"github.com/pitabwire/util"
 )
 
+const entityTypePayment = "payment"
+
 type StatusSave struct {
-	statusRepo repository.StatusRepository
+	statusRepo     repository.StatusRepository
+	paymentRepo    repository.PaymentRepository
+	paymentMetrics *metrics.PaymentMetrics
 }
 
 // NewStatusSave creates a new StatusSave event handler with the required dependencies.
-func NewStatusSave(statusRepo repository.StatusRepository) *StatusSave {
+func NewStatusSave(
+	statusRepo repository.StatusRepository,
+	paymentRepo repository.PaymentRepository,
+) *StatusSave {
 	return &StatusSave{
-		statusRepo: statusRepo,
+		statusRepo:     statusRepo,
+		paymentRepo:    paymentRepo,
+		paymentMetrics: metrics.NewPaymentMetrics(),
 	}
 }
 
@@ -78,5 +88,26 @@ func (e *StatusSave) Execute(ctx context.Context, payload any) error {
 	}
 	logger.Debug("successfully saved record to db")
 
+	e.recordPaymentMetrics(ctx, status)
+
 	return nil
+}
+
+// recordPaymentMetrics emits business metrics for payments reaching a
+// terminal status. All payment status transitions funnel through this event
+// handler, so terminal outcomes from every path are captured here.
+func (e *StatusSave) recordPaymentMetrics(ctx context.Context, status *models.Status) {
+	if status.EntityType != entityTypePayment || !metrics.IsTerminalStatus(status.Status) {
+		return
+	}
+
+	p, err := e.paymentRepo.GetByID(ctx, status.EntityID)
+	if err != nil {
+		util.Log(ctx).WithError(err).
+			WithField("entity_id", status.EntityID).
+			Warn("could not load payment for terminal status metrics")
+		return
+	}
+
+	e.paymentMetrics.RecordTerminal(ctx, p, status)
 }

--- a/apps/default/service/metrics/metrics.go
+++ b/apps/default/service/metrics/metrics.go
@@ -1,0 +1,139 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics defines the tenant-scoped business instruments for the
+// payment lifecycle. Instruments are created through frame's
+// telemetry.BusinessMetrics factory, so every measurement transparently
+// carries tenant_id and partition_id derived from the context claims.
+package metrics
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/antinvestor/service-payments/apps/default/service/models"
+	"github.com/pitabwire/frame/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const unknownAttrValue = "unknown"
+
+// PaymentMetrics groups the business instruments for the payment lifecycle.
+type PaymentMetrics struct {
+	initiated  telemetry.Counter
+	succeeded  telemetry.Counter
+	failed     telemetry.Counter
+	amount     telemetry.FloatCounter
+	processing telemetry.Histogram
+}
+
+// NewPaymentMetrics creates the payment business instruments. The underlying
+// OTel SDK deduplicates instruments by name, so multiple constructions are
+// safe and record into the same series.
+func NewPaymentMetrics() *PaymentMetrics {
+	bm := telemetry.NewBusinessMetrics("service-payments")
+	return &PaymentMetrics{
+		initiated: bm.Counter(
+			"payments_initiated_total",
+			"Payments accepted for processing",
+		),
+		succeeded: bm.Counter(
+			"payments_succeeded_total",
+			"Payments that reached a successful terminal status",
+		),
+		failed: bm.Counter(
+			"payments_failed_total",
+			"Payments that reached a failed terminal status",
+		),
+		amount: bm.FloatCounter(
+			"payments_amount_total",
+			"Value of successful payments in major currency units",
+		),
+		processing: bm.Histogram(
+			"payments_processing_duration_ms",
+			"Time from payment initiation to terminal status",
+		),
+	}
+}
+
+func providerOf(p *models.Payment) string {
+	if p == nil || p.RouteID == "" {
+		return unknownAttrValue
+	}
+	return p.RouteID
+}
+
+// failureReason derives a bounded-cardinality reason from the status extras.
+func failureReason(status *models.Status) string {
+	if step := status.Extra.GetString("step"); step != "" {
+		return step
+	}
+	if status.Extra.GetString("error") != "" {
+		return "provider_error"
+	}
+	return unknownAttrValue
+}
+
+// RecordInitiated counts a payment accepted for processing.
+func (m *PaymentMetrics) RecordInitiated(ctx context.Context, p *models.Payment) {
+	if m == nil {
+		return
+	}
+	m.initiated.Add(ctx, 1, attribute.String("provider", providerOf(p)))
+}
+
+// IsTerminalStatus reports whether a status value is a terminal payment
+// outcome worth recording.
+func IsTerminalStatus(status int32) bool {
+	s := commonv1.STATUS(status)
+	return s == commonv1.STATUS_SUCCESSFUL || s == commonv1.STATUS_FAILED
+}
+
+// RecordTerminal records a payment reaching a terminal status: success or
+// failure counters, the amount moved on success, and the processing duration.
+func (m *PaymentMetrics) RecordTerminal(ctx context.Context, p *models.Payment, status *models.Status) {
+	if m == nil || p == nil || status == nil {
+		return
+	}
+
+	providerAttr := attribute.String("provider", providerOf(p))
+	elapsedMs := float64(time.Since(p.CreatedAt).Milliseconds())
+
+	outcome := commonv1.STATUS(status.Status)
+	if outcome == commonv1.STATUS_SUCCESSFUL {
+		m.succeeded.Add(ctx, 1, providerAttr)
+		m.processing.Record(ctx, elapsedMs, providerAttr)
+
+		if p.Amount == nil {
+			return
+		}
+		amount, err := strconv.ParseFloat(p.Amount.String(), 64)
+		if err != nil {
+			return
+		}
+		currency := p.Currency
+		if currency == "" {
+			currency = unknownAttrValue
+		}
+		m.amount.Add(ctx, amount, providerAttr, attribute.String("currency", currency))
+		return
+	}
+
+	if outcome == commonv1.STATUS_FAILED {
+		m.failed.Add(ctx, 1, providerAttr, attribute.String("reason", failureReason(status)))
+		m.processing.Record(ctx, elapsedMs, providerAttr)
+	}
+}

--- a/apps/default/service/metrics/metrics_test.go
+++ b/apps/default/service/metrics/metrics_test.go
@@ -1,0 +1,142 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/antinvestor/service-payments/apps/default/service/metrics"
+	"github.com/antinvestor/service-payments/apps/default/service/models"
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/util/decimalx"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func dataPointAttrSets(aggregation metricdata.Aggregation) []attribute.Set {
+	var out []attribute.Set
+	switch d := aggregation.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+	case metricdata.Sum[float64]:
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+	}
+	return out
+}
+
+func metricAttrSets(rm metricdata.ResourceMetrics, name string) []attribute.Set {
+	var out []attribute.Set
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				out = append(out, dataPointAttrSets(m.Data)...)
+			}
+		}
+	}
+	return out
+}
+
+func requireAttr(t *testing.T, set attribute.Set, key, want string) {
+	t.Helper()
+	v, ok := set.Value(attribute.Key(key))
+	require.True(t, ok, "attribute %q must be present", key)
+	require.Equal(t, want, v.AsString(), "attribute %q", key)
+}
+
+// Payment lifecycle metrics must transparently carry tenant_id and
+// partition_id from the request context claims alongside their business
+// attributes.
+func TestPaymentMetricsTenantScoped(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	claims := &security.AuthenticationClaims{TenantID: "tenant-x", PartitionID: "part-y"}
+	claims.Subject = "user-tenant-x"
+	ctx := claims.ClaimsToContext(context.Background())
+
+	pm := metrics.NewPaymentMetrics()
+
+	amount := decimalx.New(12345, -2) // 123.45 major units
+	p := &models.Payment{
+		RouteID:  "mpesa-route",
+		Amount:   amount.Ptr(),
+		Currency: "KES",
+	}
+	p.CreatedAt = time.Now().Add(-time.Second)
+
+	pm.RecordInitiated(ctx, p)
+	pm.RecordTerminal(ctx, p, &models.Status{
+		EntityType: "payment",
+		Status:     int32(commonv1.STATUS_SUCCESSFUL.Number()),
+	})
+	pm.RecordTerminal(ctx, p, &models.Status{
+		EntityType: "payment",
+		Status:     int32(commonv1.STATUS_FAILED.Number()),
+		Extra:      data.JSONMap{"error": "insufficient funds"},
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, name := range []string{
+		"payments_initiated_total",
+		"payments_succeeded_total",
+		"payments_failed_total",
+		"payments_amount_total",
+		"payments_processing_duration_ms",
+	} {
+		sets := metricAttrSets(rm, name)
+		require.Len(t, sets, 1, "%s must have exactly one datapoint", name)
+		requireAttr(t, sets[0], "tenant_id", "tenant-x")
+		requireAttr(t, sets[0], "partition_id", "part-y")
+		requireAttr(t, sets[0], "provider", "mpesa-route")
+	}
+
+	amountSets := metricAttrSets(rm, "payments_amount_total")
+	requireAttr(t, amountSets[0], "currency", "KES")
+
+	failedSets := metricAttrSets(rm, "payments_failed_total")
+	requireAttr(t, failedSets[0], "reason", "provider_error")
+
+	// The amount counter must record major units.
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "payments_amount_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[float64])
+			require.True(t, ok)
+			require.InDelta(t, 123.45, sum.DataPoints[0].Value, 0.0001)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/moby/moby/api v1.54.2
-	github.com/pitabwire/frame v1.98.2
+	github.com/pitabwire/frame v1.98.4
 	github.com/pitabwire/util v0.9.1
 	github.com/pitabwire/util/decimalx v0.7.2
 	github.com/pitabwire/util/moneyx v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.2 h1:Kv/9w4+P/2En9hGBrXawNPOk0DMwek8HUg0A21WMnu8=
-github.com/pitabwire/frame v1.98.2/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
+github.com/pitabwire/frame v1.98.4 h1:yGrVLMlc+2rqHMoXL124VZ7RJW/zHyqkaZ4R7TP7HiQ=
+github.com/pitabwire/frame v1.98.4/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary

Adds first-class business instrumentation for the payment lifecycle so the analytics pages have real data. Instruments are created via frame's `telemetry.NewBusinessMetrics`, so every datapoint transparently carries `tenant_id` / `partition_id` from the request context claims.

### Metrics (contract for analytics)

| Metric | Type | Attributes | Recorded at |
|---|---|---|---|
| `payments_initiated_total` | counter | `provider` | business layer `Send` / `Receive` after the payment is accepted |
| `payments_succeeded_total` | counter | `provider` | `StatusSave` event sink on terminal `STATUS_SUCCESSFUL` |
| `payments_failed_total` | counter | `provider`, `reason` | `StatusSave` event sink on terminal `STATUS_FAILED` |
| `payments_amount_total` | float counter (major units) | `provider`, `currency` | with `payments_succeeded_total` |
| `payments_processing_duration_ms` | histogram | `provider` | initiation -> terminal status latency |

### Design

- `apps/default` owns payment state (ledger/billing apps don't transition payments); all terminal transitions funnel through the `StatusSave` event handler, which now loads the payment for provider/amount/currency attribution.
- `provider` is the payment route ID (bounded, routes are configured); `reason` is bounded: the `step` extra when present, else `provider_error` when the status carries an error, else `unknown`.
- `subscriptions_active` gauge was skipped: the billing subscription repo has no count surface, so there is no cheap natural point — would need new query surface.

### Testing

- `TestPaymentMetricsTenantScoped` (ManualReader) proves each instrument records a datapoint carrying `tenant_id`/`partition_id` from claims ctx, the amount counter records major units (123.45), and failure reason mapping works.
- `go build ./...` clean, `golangci-lint` 0 issues on changed packages, `./apps/default/...` suites green with `-count=1`.