### PR TITLE
chore(ui): payment 0.2.1 — ui_core ^0.5.0

### DIFF
--- a/ui/payment/pubspec.yaml
+++ b/ui/payment/pubspec.yaml
@@ -16,7 +16,7 @@ name: antinvestor_ui_payment
 description: >
   Payment management UI library for Antinvestor. Embeddable screens and widgets
   for payments, payment links, and reconciliation.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/antinvestor/service-payment
 homepage: https://github.com/antinvestor/service-payment/tree/main/ui/payment
 issue_tracker: https://github.com/antinvestor/service-payment/issues
@@ -33,7 +33,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.4.0
+  antinvestor_ui_core: ^0.5.0
   antinvestor_api_payment: ^1.53.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0


### PR DESCRIPTION
Published 0.2.0 shipped its own formatMoney that collides with ui_core ≥0.5.0 at dart2js; local code already uses the shared helper. Published 0.2.1.