### PR TITLE
feat(billing): hosted checkout collection for invoices

### DIFF
--- a/apps/billing/cmd/main.go
+++ b/apps/billing/cmd/main.go
@@ -25,12 +25,15 @@ import (
 	billingpb "buf.build/gen/go/antinvestor/billing/protocolbuffers/go/v1"
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
+	apis "github.com/antinvestor/common"
+	"github.com/antinvestor/common/connection"
 	"github.com/antinvestor/common/timescale"
 	aconfig "github.com/antinvestor/service-payments/apps/billing/config"
 	"github.com/antinvestor/service-payments/apps/billing/service/business"
 	"github.com/antinvestor/service-payments/apps/billing/service/handlers"
 	"github.com/antinvestor/service-payments/apps/billing/service/models"
 	"github.com/antinvestor/service-payments/apps/billing/service/repository"
+	"github.com/antinvestor/service-payments/apps/checkout/gen/checkout/v1/checkoutv1connect"
 
 	// Ledger integration dependencies.
 	ledgerBusiness "github.com/antinvestor/service-payments/apps/ledger/service/business"
@@ -114,9 +117,17 @@ func main() {
 	creditEng := business.NewCreditEngine(workMan, dbPool, creditGrantRepo, creditEntryRepo)
 	invoiceEng := business.NewInvoiceEngine(workMan, dbPool, invoiceRepo, invoiceLineRepo)
 	ledgerInteg := business.NewLedgerIntegration(ledgerTxnBusiness)
+
+	checkoutCli, checkoutErr := setupCheckoutClient(ctx, cfg)
+	if checkoutErr != nil {
+		log.WithError(checkoutErr).Error("could not setup checkout client")
+		return
+	}
+	checkoutInteg := business.NewCheckoutIntegration(checkoutCli, invoiceRepo, invoiceEng, cfg.CheckoutInvoiceReturnURL)
+
 	billingWorkflow := business.NewBillingWorkflow(
 		workMan, billingRunRepo, ratedLineRepo, subscriptionBus, catalogBus, componentRepo,
-		meteringEng, pricingEng, discountEng, creditEng, invoiceEng, ledgerInteg)
+		meteringEng, pricingEng, discountEng, creditEng, invoiceEng, ledgerInteg, checkoutInteg)
 
 	// Create handler with injected business layer
 	billingServer := handlers.NewBillingServer(
@@ -145,6 +156,18 @@ func main() {
 	if err != nil {
 		log.WithError(err).Error("could not run Server")
 	}
+}
+
+// setupCheckoutClient creates a gRPC client for the checkout service.
+func setupCheckoutClient(
+	ctx context.Context,
+	cfg aconfig.BillingConfig,
+) (checkoutv1connect.CheckoutServiceClient, error) {
+	return connection.NewServiceClient(ctx, &cfg, apis.ServiceTarget{
+		Endpoint:              cfg.CheckoutServiceURI,
+		WorkloadAPITargetPath: cfg.CheckoutServiceWorkloadAPITargetPath,
+		Audiences:             []string{"service_payment_checkout"},
+	}, checkoutv1connect.NewCheckoutServiceClient)
 }
 
 // ensureHypertables registers TimescaleDB hypertables idempotently.

--- a/apps/billing/service/business/billing_workflow.go
+++ b/apps/billing/service/business/billing_workflow.go
@@ -16,6 +16,7 @@ package business
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,6 +34,10 @@ import (
 type BillingWorkflow interface {
 	RunBilling(ctx context.Context, subscriptionID string, periodStart, periodEnd time.Time) (*models.BillingRun, error)
 	GetBillingRun(ctx context.Context, id string) (*models.BillingRun, error)
+	// CollectInvoice creates a hosted checkout session for an issued invoice.
+	CollectInvoice(ctx context.Context, invoiceID string) (*InvoiceCheckout, error)
+	// SettleInvoiceFromCheckout marks an invoice as paid from a completed checkout session.
+	SettleInvoiceFromCheckout(ctx context.Context, sessionRef string) (*models.Invoice, error)
 }
 
 type billingWorkflow struct {
@@ -48,6 +53,7 @@ type billingWorkflow struct {
 	creditEng       CreditEngine
 	invoiceEng      InvoiceEngine
 	ledgerInteg     LedgerIntegration
+	checkout        CheckoutIntegration
 	obs             *observability.Metrics
 }
 
@@ -64,6 +70,7 @@ func NewBillingWorkflow(
 	creditEng CreditEngine,
 	invoiceEng InvoiceEngine,
 	ledgerInteg LedgerIntegration,
+	checkoutInteg CheckoutIntegration,
 ) BillingWorkflow {
 	return &billingWorkflow{
 		workMan:         workMan,
@@ -78,6 +85,7 @@ func NewBillingWorkflow(
 		creditEng:       creditEng,
 		invoiceEng:      invoiceEng,
 		ledgerInteg:     ledgerInteg,
+		checkout:        checkoutInteg,
 		obs:             observability.NewMetrics(),
 	}
 }
@@ -350,4 +358,28 @@ func (w *billingWorkflow) GetBillingRun(ctx context.Context, id string) (*models
 	}
 
 	return w.runRepo.GetByID(ctx, id)
+}
+
+// CollectInvoice creates a hosted checkout session for an issued invoice.
+// Returns an error if the checkout integration is not configured.
+func (w *billingWorkflow) CollectInvoice(
+	ctx context.Context,
+	invoiceID string,
+) (*InvoiceCheckout, error) {
+	if w.checkout == nil {
+		return nil, errors.New("checkout integration not configured")
+	}
+	return w.checkout.CreateInvoiceCheckout(ctx, invoiceID)
+}
+
+// SettleInvoiceFromCheckout marks an invoice as paid from a completed checkout session.
+// Returns an error if the checkout integration is not configured.
+func (w *billingWorkflow) SettleInvoiceFromCheckout(
+	ctx context.Context,
+	sessionRef string,
+) (*models.Invoice, error) {
+	if w.checkout == nil {
+		return nil, errors.New("checkout integration not configured")
+	}
+	return w.checkout.SettleFromCheckout(ctx, sessionRef)
 }

--- a/apps/billing/service/business/checkout_integration.go
+++ b/apps/billing/service/business/checkout_integration.go
@@ -1,0 +1,208 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/antinvestor/service-payments/apps/billing/service/models"
+	"github.com/antinvestor/service-payments/apps/billing/service/observability"
+	"github.com/antinvestor/service-payments/apps/billing/service/repository"
+	checkoutv1 "github.com/antinvestor/service-payments/apps/checkout/gen/checkout/v1"
+	"github.com/antinvestor/service-payments/apps/checkout/gen/checkout/v1/checkoutv1connect"
+	"github.com/antinvestor/service-payments/pkg/apperrors"
+	"github.com/pitabwire/util"
+)
+
+// ErrCheckoutNotCompleted is returned when a checkout session has not yet
+// reached the SESSION_STATUS_COMPLETED state.
+var ErrCheckoutNotCompleted = errors.New("checkout session is not completed")
+
+// InvoiceCheckout carries the result of a successfully created checkout
+// session for an invoice.
+type InvoiceCheckout struct {
+	SessionRef string
+	PageURL    string
+}
+
+// CheckoutIntegration creates hosted checkout sessions for issued invoices
+// and settles invoices from verified completed sessions.
+type CheckoutIntegration interface {
+	CreateInvoiceCheckout(ctx context.Context, invoiceID string) (*InvoiceCheckout, error)
+	SettleFromCheckout(ctx context.Context, sessionRef string) (*models.Invoice, error)
+}
+
+type checkoutIntegration struct {
+	checkoutCli checkoutv1connect.CheckoutServiceClient
+	invoiceRepo repository.InvoiceRepository
+	invoiceEng  InvoiceEngine
+	returnURL   string
+	obs         *observability.Metrics
+}
+
+// NewCheckoutIntegration returns a CheckoutIntegration that calls the checkout
+// service and settles invoices via the invoice engine.
+func NewCheckoutIntegration(
+	checkoutCli checkoutv1connect.CheckoutServiceClient,
+	invoiceRepo repository.InvoiceRepository,
+	invoiceEng InvoiceEngine,
+	returnURL string,
+) CheckoutIntegration {
+	return &checkoutIntegration{
+		checkoutCli: checkoutCli,
+		invoiceRepo: invoiceRepo,
+		invoiceEng:  invoiceEng,
+		returnURL:   returnURL,
+		obs:         observability.NewMetrics(),
+	}
+}
+
+// CreateInvoiceCheckout creates a hosted checkout session for an issued
+// invoice and returns the session reference and page URL.
+//
+//nolint:nonamedreturns // named err captured by deferred span-end closure
+func (c *checkoutIntegration) CreateInvoiceCheckout(
+	ctx context.Context,
+	invoiceID string,
+) (result *InvoiceCheckout, err error) {
+	ctx, span := c.obs.StartSpan(ctx, "CreateInvoiceCheckout")
+	defer func() {
+		c.obs.EndSpan(ctx, span, err)
+	}()
+
+	if invoiceID == "" {
+		return nil, ErrInvoiceIDRequired
+	}
+
+	invoice, err := c.invoiceRepo.GetByID(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if invoice.State != models.InvoiceStateIssued {
+		return nil, apperrors.ErrInvoiceNotPayable
+	}
+
+	money, err := moneyFromDecimal(invoice.TotalAmount, invoice.Currency)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build checkout amount: %w", err)
+	}
+
+	req := &checkoutv1.CreateCheckoutSessionRequest{
+		Name:     "Invoice " + invoice.InvoiceNumber,
+		OrderRef: invoice.GetID(),
+		Amount:   money,
+		Metadata: map[string]string{
+			"invoiceId":     invoice.GetID(),
+			"invoiceNumber": invoice.InvoiceNumber,
+		},
+	}
+
+	if invoice.ProfileID != "" {
+		req.Payer = &checkoutv1.PayerPrefill{
+			ProfileId: invoice.ProfileID,
+		}
+	}
+
+	if c.returnURL != "" {
+		req.ReturnUrl = c.returnURL
+	}
+
+	resp, err := c.checkoutCli.CreateCheckoutSession(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("create checkout session: %w", err)
+	}
+
+	data := resp.Msg.GetData()
+
+	util.Log(ctx).
+		WithField("invoice_id", invoiceID).
+		WithField("session_ref", data.GetRef()).
+		Info("checkout session created for invoice")
+
+	return &InvoiceCheckout{
+		SessionRef: data.GetRef(),
+		PageURL:    data.GetPageUrl(),
+	}, nil
+}
+
+// SettleFromCheckout verifies that a checkout session is completed, matches
+// the invoice amount, and then calls RecordPayment to mark the invoice paid.
+//
+//nolint:nonamedreturns // named err captured by deferred span-end closure
+func (c *checkoutIntegration) SettleFromCheckout(
+	ctx context.Context,
+	sessionRef string,
+) (result *models.Invoice, err error) {
+	ctx, span := c.obs.StartSpan(ctx, "SettleFromCheckout")
+	defer func() {
+		c.obs.EndSpan(ctx, span, err)
+	}()
+
+	if sessionRef == "" {
+		return nil, apperrors.ErrUnspecifiedReference
+	}
+
+	resp, err := c.checkoutCli.GetCheckoutSession(
+		ctx,
+		connect.NewRequest(&checkoutv1.GetCheckoutSessionRequest{Ref: sessionRef}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get checkout session: %w", err)
+	}
+
+	session := resp.Msg.GetData()
+	if session.GetStatus() != checkoutv1.SessionStatus_SESSION_STATUS_COMPLETED {
+		return nil, ErrCheckoutNotCompleted
+	}
+
+	invoiceID := session.GetOrderRef()
+	if invoiceID == "" {
+		return nil, fmt.Errorf("checkout session %q has no order_ref", sessionRef)
+	}
+
+	invoice, err := c.invoiceRepo.GetByID(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Idempotent: already paid → return without error.
+	if invoice.State == models.InvoiceStatePaid {
+		return invoice, nil
+	}
+
+	// Verify session amount matches invoice total.
+	if !moneyMatchesDecimal(session.GetAmount(), invoice.TotalAmount, invoice.Currency) {
+		return nil, fmt.Errorf(
+			"amount mismatch: checkout session amount does not match invoice total for invoice %s",
+			invoiceID,
+		)
+	}
+
+	invoice, err = c.invoiceEng.RecordPayment(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	util.Log(ctx).
+		WithField("invoice_id", invoiceID).
+		WithField("session_ref", sessionRef).
+		Info("invoice settled from checkout session")
+
+	return invoice, nil
+}

--- a/apps/billing/service/business/checkout_integration_test.go
+++ b/apps/billing/service/business/checkout_integration_test.go
@@ -1,0 +1,678 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"buf.build/gen/go/antinvestor/payment/connectrpc/go/v1/paymentv1connect"
+	paymentv1 "buf.build/gen/go/antinvestor/payment/protocolbuffers/go/v1"
+	"buf.build/gen/go/antinvestor/profile/connectrpc/go/profile/v1/profilev1connect"
+	profilev1 "buf.build/gen/go/antinvestor/profile/protocolbuffers/go/profile/v1"
+	"connectrpc.com/connect"
+	"github.com/antinvestor/service-payments/apps/billing/service/business"
+	"github.com/antinvestor/service-payments/apps/billing/service/models"
+	billingTests "github.com/antinvestor/service-payments/apps/billing/tests"
+	checkoutConfig "github.com/antinvestor/service-payments/apps/checkout/config"
+	"github.com/antinvestor/service-payments/apps/checkout/gen/checkout/v1/checkoutv1connect"
+	checkoutBusiness "github.com/antinvestor/service-payments/apps/checkout/service/business"
+	checkoutHandlers "github.com/antinvestor/service-payments/apps/checkout/service/handlers"
+	checkoutModels "github.com/antinvestor/service-payments/apps/checkout/service/models"
+	checkoutRepo "github.com/antinvestor/service-payments/apps/checkout/service/repository"
+	"github.com/antinvestor/service-payments/pkg/apperrors"
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/pitabwire/util/decimalx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// Fake checkout-side repos (re-declared — they're package-local in checkout tests)
+// ---------------------------------------------------------------------------
+
+type fakeCheckoutSessionRepo struct {
+	checkoutRepo.SessionRepository
+	sessions  map[string]*checkoutModels.CheckoutSession
+	createErr error
+	updateErr error
+}
+
+func newFakeCheckoutSessionRepo() *fakeCheckoutSessionRepo {
+	return &fakeCheckoutSessionRepo{
+		sessions: make(map[string]*checkoutModels.CheckoutSession),
+	}
+}
+
+func (f *fakeCheckoutSessionRepo) Create(_ context.Context, s *checkoutModels.CheckoutSession) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.sessions[s.Ref] = s
+	return nil
+}
+
+func (f *fakeCheckoutSessionRepo) Update(
+	_ context.Context,
+	s *checkoutModels.CheckoutSession,
+	_ ...string,
+) (int64, error) {
+	if f.updateErr != nil {
+		return 0, f.updateErr
+	}
+	f.sessions[s.Ref] = s
+	return 1, nil
+}
+
+func (f *fakeCheckoutSessionRepo) GetByRef(_ context.Context, ref string) (*checkoutModels.CheckoutSession, error) {
+	s, ok := f.sessions[ref]
+	if !ok {
+		return nil, fmt.Errorf("session %q: %w", ref, gorm.ErrRecordNotFound)
+	}
+	return s, nil
+}
+
+func (f *fakeCheckoutSessionRepo) ListByStatus(
+	_ context.Context,
+	status string,
+	limit int,
+) ([]*checkoutModels.CheckoutSession, error) {
+	var list []*checkoutModels.CheckoutSession
+	for _, s := range f.sessions {
+		if s.Status == status {
+			list = append(list, s)
+		}
+		if len(list) >= limit {
+			break
+		}
+	}
+	return list, nil
+}
+
+// ---------------------------------------------------------------------------
+
+type fakeCheckoutLinkRepo struct {
+	checkoutRepo.LinkRepository
+	links map[string]*checkoutModels.CheckoutLink
+}
+
+func newFakeCheckoutLinkRepo() *fakeCheckoutLinkRepo {
+	return &fakeCheckoutLinkRepo{links: make(map[string]*checkoutModels.CheckoutLink)}
+}
+
+func (f *fakeCheckoutLinkRepo) Create(_ context.Context, l *checkoutModels.CheckoutLink) error {
+	f.links[l.Ref] = l
+	return nil
+}
+
+func (f *fakeCheckoutLinkRepo) Update(
+	_ context.Context,
+	l *checkoutModels.CheckoutLink,
+	_ ...string,
+) (int64, error) {
+	f.links[l.Ref] = l
+	return 1, nil
+}
+
+func (f *fakeCheckoutLinkRepo) GetByRef(_ context.Context, ref string) (*checkoutModels.CheckoutLink, error) {
+	l, ok := f.links[ref]
+	if !ok {
+		return nil, fmt.Errorf("link %q: %w", ref, gorm.ErrRecordNotFound)
+	}
+	return l, nil
+}
+
+// ---------------------------------------------------------------------------
+
+type fakeCheckoutPaymentClient struct {
+	paymentv1connect.PaymentServiceClient
+	promptResp *connect.Response[paymentv1.InitiatePromptResponse]
+	statusResp *connect.Response[commonv1.StatusResponse]
+}
+
+func (f *fakeCheckoutPaymentClient) InitiatePrompt(
+	_ context.Context,
+	_ *connect.Request[paymentv1.InitiatePromptRequest],
+) (*connect.Response[paymentv1.InitiatePromptResponse], error) {
+	if f.promptResp != nil {
+		return f.promptResp, nil
+	}
+	return connect.NewResponse(&paymentv1.InitiatePromptResponse{
+		Data: &commonv1.StatusResponse{Id: "prompt-test-id"},
+	}), nil
+}
+
+func (f *fakeCheckoutPaymentClient) Status(
+	_ context.Context,
+	_ *connect.Request[commonv1.StatusRequest],
+) (*connect.Response[commonv1.StatusResponse], error) {
+	if f.statusResp != nil {
+		return f.statusResp, nil
+	}
+	return connect.NewResponse(&commonv1.StatusResponse{Status: commonv1.STATUS_IN_PROCESS}), nil
+}
+
+// ---------------------------------------------------------------------------
+
+type fakeCheckoutProfileClient struct {
+	profilev1connect.ProfileServiceClient
+}
+
+//nolint:revive,staticcheck // GetById matches generated interface name.
+func (f *fakeCheckoutProfileClient) GetById(
+	_ context.Context,
+	_ *connect.Request[profilev1.GetByIdRequest],
+) (*connect.Response[profilev1.GetByIdResponse], error) {
+	return connect.NewResponse(&profilev1.GetByIdResponse{}), nil
+}
+
+func (f *fakeCheckoutProfileClient) Update(
+	_ context.Context,
+	_ *connect.Request[profilev1.UpdateRequest],
+) (*connect.Response[profilev1.UpdateResponse], error) {
+	return connect.NewResponse(&profilev1.UpdateResponse{}), nil
+}
+
+// ---------------------------------------------------------------------------
+// checkoutTestHarness: real checkout service on an httptest server
+// ---------------------------------------------------------------------------
+
+type checkoutTestHarness struct {
+	sessionRepo *fakeCheckoutSessionRepo
+	server      *httptest.Server
+	client      checkoutv1connect.CheckoutServiceClient
+}
+
+func newCheckoutTestHarness(t *testing.T) *checkoutTestHarness {
+	t.Helper()
+
+	sessionRepo := newFakeCheckoutSessionRepo()
+	linkRepo := newFakeCheckoutLinkRepo()
+	payCli := &fakeCheckoutPaymentClient{}
+	profCli := &fakeCheckoutProfileClient{}
+
+	cfg := &checkoutConfig.CheckoutConfig{
+		SessionTTLMinutes:      30,
+		MaxAttempts:            3,
+		AttemptCooldownSeconds: 20,
+		MethodsJSON:            `[{"key":"mpesa","name":"M-PESA","route":"mpesa","prefixes":["254"],"currencies":["KES"]}]`,
+		PublicBaseURL:          "http://localhost:8080",
+	}
+
+	reg, err := checkoutBusiness.ParseMethodRegistry(cfg.MethodsJSON)
+	require.NoError(t, err)
+
+	biz := checkoutBusiness.NewCheckoutBusiness(cfg, reg, sessionRepo, linkRepo, payCli, profCli, nil)
+
+	rpcServer := checkoutHandlers.NewCheckoutServer(biz, cfg)
+	mux := http.NewServeMux()
+	path, h := checkoutv1connect.NewCheckoutServiceHandler(rpcServer)
+	mux.Handle(path, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cli := checkoutv1connect.NewCheckoutServiceClient(srv.Client(), srv.URL)
+
+	return &checkoutTestHarness{
+		sessionRepo: sessionRepo,
+		server:      srv,
+		client:      cli,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckoutIntegrationSuite
+// ---------------------------------------------------------------------------
+
+type CheckoutIntegrationSuite struct {
+	billingTests.BaseTestSuite
+}
+
+func TestCheckoutIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(CheckoutIntegrationSuite))
+}
+
+// makeIssuedInvoice creates and issues an invoice via the real billing engine.
+// All test invoices use "KES" as currency.
+//
+//nolint:revive // t first is idiomatic for test helpers; ctx follows
+func makeIssuedInvoice(
+	t *testing.T,
+	ctx context.Context,
+	resources *billingTests.ServiceResources,
+	profileID string,
+	amount string,
+) *models.Invoice {
+	t.Helper()
+
+	const currency = "KES"
+
+	invoiceEng := resources.InvoiceEngine
+	billingRunRepo := resources.BillingRunRepo
+
+	// Create a billing run to associate the invoice with.
+	runID := util.IDString()
+	now := time.Now()
+	run := &models.BillingRun{
+		BaseModel:        data.BaseModel{ID: runID},
+		SubscriptionID:   util.IDString(),
+		ProfileID:        profileID,
+		CatalogVersionID: util.IDString(),
+		State:            models.BillingRunStatePending,
+		PeriodStart:      now.AddDate(0, -1, 0),
+		PeriodEnd:        now,
+		Idempotency:      runID,
+	}
+	err := billingRunRepo.Create(ctx, run)
+	require.NoError(t, err)
+
+	amtDecimal, err := decimalx.NewFromString(amount)
+	require.NoError(t, err)
+
+	rl := &models.RatedLine{
+		BaseModel:      data.BaseModel{ID: util.IDString()},
+		BillingRunID:   runID,
+		SubscriptionID: run.SubscriptionID,
+		ComponentID:    util.IDString(),
+		Description:    "test line",
+		Amount:         amtDecimal.Ptr(),
+		Currency:       currency,
+	}
+	rl.GenID(ctx)
+
+	invoice, err := invoiceEng.GenerateInvoice(ctx, run, []*models.RatedLine{rl}, nil, decimalx.Zero())
+	require.NoError(t, err)
+
+	invoice, err = invoiceEng.IssueInvoice(ctx, invoice.GetID())
+	require.NoError(t, err)
+	require.Equal(t, models.InvoiceStateIssued, invoice.State)
+
+	return invoice
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+
+// 1. CreateInvoiceCheckout: session created, order_ref == invoice id, money + metadata + payer correct.
+func (ts *CheckoutIntegrationSuite) TestCreateInvoiceCheckout_SessionCreated() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		invoice := makeIssuedInvoice(t, ctx, resources, profileID, "100.00")
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		result, err := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.SessionRef)
+		assert.Contains(t, result.PageURL, "/c/", "page URL should contain /c/")
+
+		// Verify the stored session has correct order_ref, money, metadata, and payer.
+		stored := ch.sessionRepo.sessions[result.SessionRef]
+		require.NotNil(t, stored, "session must be stored in fake repo")
+
+		assert.Equal(t, invoice.GetID(), stored.OrderRef, "order_ref must be invoice ID")
+		assert.Equal(t, "100", stored.Amount, "amount must match invoice total")
+		assert.Equal(t, "KES", stored.Currency)
+
+		if invoiceMeta, ok := stored.Metadata["invoiceId"]; ok {
+			assert.Equal(t, invoice.GetID(), invoiceMeta)
+		}
+		if invNum, ok := stored.Metadata["invoiceNumber"]; ok {
+			assert.Equal(t, invoice.InvoiceNumber, invNum)
+		}
+
+		assert.Equal(t, profileID, stored.PayerProfileID, "payer profile id should be set")
+	})
+}
+
+// 2. CreateInvoiceCheckout on DRAFT invoice → not-payable error.
+func (ts *CheckoutIntegrationSuite) TestCreateInvoiceCheckout_DraftInvoice_NotPayable() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		// Create a DRAFT invoice (not issued).
+		billingRunRepo := resources.BillingRunRepo
+		invoiceEng := resources.InvoiceEngine
+
+		runID := util.IDString()
+		now := time.Now()
+		run := &models.BillingRun{
+			BaseModel:        data.BaseModel{ID: runID},
+			SubscriptionID:   util.IDString(),
+			ProfileID:        profileID,
+			CatalogVersionID: util.IDString(),
+			State:            models.BillingRunStatePending,
+			PeriodStart:      now.AddDate(0, -1, 0),
+			PeriodEnd:        now,
+			Idempotency:      runID,
+		}
+		err := billingRunRepo.Create(ctx, run)
+		require.NoError(t, err)
+
+		amt := decimalx.New(5000, -2) // 50.00
+		rl := &models.RatedLine{
+			BaseModel:      data.BaseModel{ID: util.IDString()},
+			BillingRunID:   runID,
+			SubscriptionID: run.SubscriptionID,
+			ComponentID:    util.IDString(),
+			Description:    "test",
+			Amount:         amt.Ptr(),
+			Currency:       "KES",
+		}
+		rl.GenID(ctx)
+
+		invoice, err := invoiceEng.GenerateInvoice(ctx, run, []*models.RatedLine{rl}, nil, decimalx.Zero())
+		require.NoError(t, err)
+		require.Equal(t, models.InvoiceStateDraft, invoice.State)
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		_, checkoutErr := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+
+		require.Error(t, checkoutErr)
+		require.ErrorIs(t, checkoutErr, apperrors.ErrInvoiceNotPayable,
+			"draft invoice must return not-payable error")
+		assert.Empty(t, ch.sessionRepo.sessions, "no session must be created")
+	})
+}
+
+// 3. Full settle: create session, drive to completed, SettleFromCheckout → invoice PAID.
+func (ts *CheckoutIntegrationSuite) TestSettleFromCheckout_FullFlow() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		invoice := makeIssuedInvoice(t, ctx, resources, profileID, "75.00")
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		checkout, err := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+		require.NoError(t, err)
+
+		// Drive session to completed: mutate the stored session status directly.
+		stored := ch.sessionRepo.sessions[checkout.SessionRef]
+		require.NotNil(t, stored)
+		stored.Status = checkoutModels.SessionStatusCompleted
+
+		// Now settle.
+		paid, err := integ.SettleFromCheckout(ctx, checkout.SessionRef)
+
+		require.NoError(t, err)
+		require.NotNil(t, paid)
+		assert.Equal(t, models.InvoiceStatePaid, paid.State, "invoice must be PAID")
+		assert.NotNil(t, paid.PaidAt, "PaidAt must be set")
+	})
+}
+
+// 4. Idempotency: SettleFromCheckout twice → second call returns nil error, invoice still PAID.
+func (ts *CheckoutIntegrationSuite) TestSettleFromCheckout_Idempotent() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		invoice := makeIssuedInvoice(t, ctx, resources, profileID, "50.00")
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		checkout, err := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+		require.NoError(t, err)
+
+		stored := ch.sessionRepo.sessions[checkout.SessionRef]
+		require.NotNil(t, stored)
+		stored.Status = checkoutModels.SessionStatusCompleted
+
+		// First call — should pay.
+		paid1, err := integ.SettleFromCheckout(ctx, checkout.SessionRef)
+		require.NoError(t, err)
+		require.Equal(t, models.InvoiceStatePaid, paid1.State)
+
+		// Second call — must NOT error and must return the already-paid invoice.
+		paid2, err := integ.SettleFromCheckout(ctx, checkout.SessionRef)
+		require.NoError(t, err, "second SettleFromCheckout must not error (idempotent)")
+		require.NotNil(t, paid2)
+		assert.Equal(t, models.InvoiceStatePaid, paid2.State)
+	})
+}
+
+// 5. Pending session → ErrCheckoutNotCompleted, invoice still ISSUED.
+func (ts *CheckoutIntegrationSuite) TestSettleFromCheckout_PendingSession_NotCompleted() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		invoice := makeIssuedInvoice(t, ctx, resources, profileID, "30.00")
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		checkout, err := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+		require.NoError(t, err)
+
+		// Leave the session as pending (do NOT drive to completed).
+		_, settleErr := integ.SettleFromCheckout(ctx, checkout.SessionRef)
+
+		require.Error(t, settleErr)
+		require.ErrorIs(t, settleErr, business.ErrCheckoutNotCompleted)
+
+		// Invoice must still be ISSUED.
+		still, err := resources.InvoiceEngine.GetInvoice(ctx, invoice.GetID())
+		require.NoError(t, err)
+		assert.Equal(t, models.InvoiceStateIssued, still.State)
+	})
+}
+
+// 6. Amount mismatch: complete session with different amount → "mismatch" error, invoice still ISSUED.
+func (ts *CheckoutIntegrationSuite) TestSettleFromCheckout_AmountMismatch() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		ch := newCheckoutTestHarness(t)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		invoice := makeIssuedInvoice(t, ctx, resources, profileID, "200.00")
+
+		integ := business.NewCheckoutIntegration(ch.client, resources.InvoiceRepo, resources.InvoiceEngine, "")
+		checkout, err := integ.CreateInvoiceCheckout(ctx, invoice.GetID())
+		require.NoError(t, err)
+
+		// Mutate the stored session to have a different amount AND mark as completed.
+		stored := ch.sessionRepo.sessions[checkout.SessionRef]
+		require.NotNil(t, stored)
+		stored.Amount = "999" // tampered — differs from invoice 200.00
+		stored.Status = checkoutModels.SessionStatusCompleted
+
+		_, settleErr := integ.SettleFromCheckout(ctx, checkout.SessionRef)
+
+		require.Error(t, settleErr)
+		assert.Contains(t, settleErr.Error(), "mismatch",
+			"error must mention 'mismatch' when amounts differ")
+
+		still, err := resources.InvoiceEngine.GetInvoice(ctx, invoice.GetID())
+		require.NoError(t, err)
+		assert.Equal(t, models.InvoiceStateIssued, still.State, "invoice must remain ISSUED on mismatch")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 7. moneyFromDecimal unit tests (table-driven)
+// ---------------------------------------------------------------------------
+
+func TestMoneyFromDecimal(t *testing.T) {
+	tests := []struct {
+		name      string
+		amount    *string // nil = pass nil pointer
+		currency  string
+		wantErr   bool
+		wantMsg   string
+		wantUnits int64
+		wantNanos int32
+	}{
+		{
+			name:    "nil decimal",
+			amount:  nil,
+			wantErr: true,
+			wantMsg: "nil",
+		},
+		{
+			name:     "zero amount",
+			amount:   strPtr("0"),
+			currency: "KES",
+			wantErr:  true,
+			wantMsg:  "positive",
+		},
+		{
+			name:     "negative amount",
+			amount:   strPtr("-10.00"),
+			currency: "KES",
+			wantErr:  true,
+			wantMsg:  "positive",
+		},
+		{
+			name:     "too many decimal places",
+			amount:   strPtr("10.123"),
+			currency: "KES",
+			wantErr:  true,
+			wantMsg:  "decimal",
+		},
+		{
+			name:     "empty currency",
+			amount:   strPtr("10.00"),
+			currency: "",
+			wantErr:  true,
+			wantMsg:  "currency",
+		},
+		{
+			name:      "valid integer amount",
+			amount:    strPtr("100"),
+			currency:  "KES",
+			wantErr:   false,
+			wantUnits: 100,
+			wantNanos: 0,
+		},
+		{
+			name:      "valid 2dp amount",
+			amount:    strPtr("50.75"),
+			currency:  "USD",
+			wantErr:   false,
+			wantUnits: 50,
+			wantNanos: 750_000_000,
+		},
+		{
+			name:      "valid 1dp amount",
+			amount:    strPtr("25.5"),
+			currency:  "KES",
+			wantErr:   false,
+			wantUnits: 25,
+			wantNanos: 500_000_000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dp *decimalx.Decimal
+			if tt.amount != nil {
+				d, err := decimalx.NewFromString(*tt.amount)
+				require.NoError(t, err, "test input must parse as decimal")
+				dp = &d
+			}
+
+			// Call the exported wrapper for testing — since moneyFromDecimal is unexported,
+			// we test it indirectly via NewCheckoutIntegration + CreateInvoiceCheckout,
+			// but we can also expose it for direct testing via a test helper function.
+			// Here we use the public helper MoneyFromDecimalForTest.
+			money, err := business.MoneyFromDecimalForTest(dp, tt.currency)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantMsg != "" {
+					assert.Contains(t, err.Error(), tt.wantMsg)
+				}
+				assert.Nil(t, money)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, money)
+				assert.Equal(t, tt.currency, money.GetCurrencyCode())
+				assert.Equal(t, tt.wantUnits, money.GetUnits())
+				assert.Equal(t, tt.wantNanos, money.GetNanos())
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// ---------------------------------------------------------------------------
+// Verify BillingWorkflow delegates correctly when checkout is nil
+// ---------------------------------------------------------------------------
+
+func (ts *CheckoutIntegrationSuite) TestBillingWorkflow_CollectInvoice_NilCheckout() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), util.IDString())
+
+		// BillingWorkflow is constructed with nil checkout in base_testsuite.
+		workflow := resources.BillingWorkflow
+		_, err := workflow.CollectInvoice(ctx, "any-invoice-id")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checkout integration not configured")
+	})
+}
+
+// Verify SettleInvoiceFromCheckout returns error when checkout is nil.
+func (ts *CheckoutIntegrationSuite) TestBillingWorkflow_SettleInvoiceFromCheckout_NilCheckout() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), util.IDString())
+
+		workflow := resources.BillingWorkflow
+		_, err := workflow.SettleInvoiceFromCheckout(ctx, "any-session-ref")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checkout integration not configured")
+	})
+}
+
+// Ensure InvoiceRepo is exposed in ServiceResources for the test.
+// (If it's not already there, this compilation error tells us to add it.)
+var _ = (*billingTests.ServiceResources)(nil)

--- a/apps/billing/service/business/export_test.go
+++ b/apps/billing/service/business/export_test.go
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+// Package business_test helpers: exposes unexported symbols for testing.
+package business
 
 import (
-	"github.com/pitabwire/frame/config"
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/pitabwire/util/decimalx"
 )
 
-type BillingConfig struct {
-	config.ConfigurationDefault
-
-	CheckoutServiceURI                   string `envDefault:"127.0.0.1:7010"                           env:"CHECKOUT_SERVICE_URI"`
-	CheckoutServiceWorkloadAPITargetPath string `envDefault:"/ns/payments/sa/service-payment-checkout" env:"CHECKOUT_SERVICE_WORKLOAD_API_TARGET_PATH"`
-	CheckoutInvoiceReturnURL             string `                                                      env:"CHECKOUT_INVOICE_RETURN_URL"`
+// MoneyFromDecimalForTest exposes moneyFromDecimal for black-box testing.
+func MoneyFromDecimalForTest(d *decimalx.Decimal, currency string) (*commonv1.Money, error) {
+	return moneyFromDecimal(d, currency)
 }

--- a/apps/billing/service/business/money.go
+++ b/apps/billing/service/business/money.go
@@ -1,0 +1,62 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business
+
+import (
+	"errors"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/pitabwire/util/decimalx"
+	utilmoney "github.com/pitabwire/util/moneyx"
+)
+
+// moneyFromDecimal converts a decimalx.Decimal to a commonv1.Money.
+// Returns an error when d is nil, zero, negative, or has more than two
+// decimal places (to prevent silent rounding on financial amounts).
+func moneyFromDecimal(d *decimalx.Decimal, currency string) (*commonv1.Money, error) {
+	if d == nil {
+		return nil, errors.New("amount must not be nil")
+	}
+	if currency == "" {
+		return nil, errors.New("currency must not be empty")
+	}
+	if d.IsNegative() || d.IsZero() {
+		return nil, errors.New("amount must be positive")
+	}
+
+	// Reject values with more than 2 decimal places to avoid silent rounding.
+	// Convert to cents (minor units at 2dp) and back; mismatch means precision was lost.
+	const centsScale = 2
+	cents := d.ToMinorUnits(centsScale)
+	reconstructed := decimalx.FromMinorUnits(cents, centsScale)
+	if reconstructed.Cmp(*d) != 0 {
+		return nil, errors.New("amount has more than 2 decimal places: silent rounding not allowed")
+	}
+
+	return utilmoney.ToMoney(currency, *d), nil
+}
+
+// moneyMatchesDecimal returns true when the Money value equals the decimal
+// amount and currency.  Used for amount-match checks in SettleFromCheckout.
+func moneyMatchesDecimal(m *commonv1.Money, d *decimalx.Decimal, currency string) bool {
+	if m == nil || d == nil {
+		return false
+	}
+	if m.GetCurrencyCode() != currency {
+		return false
+	}
+	fromMoney := utilmoney.FromMoney(m)
+	return fromMoney.Cmp(*d) == 0
+}

--- a/apps/billing/tests/base_testsuite.go
+++ b/apps/billing/tests/base_testsuite.go
@@ -60,6 +60,7 @@ type ServiceResources struct {
 	// Repositories for direct access in tests
 	ComponentRepo  repository.ComponentRepository
 	BillingRunRepo repository.BillingRunRepository
+	InvoiceRepo    repository.InvoiceRepository
 }
 
 type BaseTestSuite struct {
@@ -168,7 +169,7 @@ func (bs *BaseTestSuite) CreateService(
 	ledgerInteg := business.NewLedgerIntegration(ledgerTxnBusiness)
 	billingWorkflow := business.NewBillingWorkflow(
 		workMan, billingRunRepo, ratedLineRepo, subscriptionBus, catalogBus, componentRepo,
-		meteringEng, pricingEng, discountEng, creditEng, invoiceEng, ledgerInteg)
+		meteringEng, pricingEng, discountEng, creditEng, invoiceEng, ledgerInteg, nil)
 
 	resources := &ServiceResources{
 		CatalogBusiness:      catalogBus,
@@ -183,6 +184,7 @@ func (bs *BaseTestSuite) CreateService(
 		LedgerIntegration:    ledgerInteg,
 		ComponentRepo:        componentRepo,
 		BillingRunRepo:       billingRunRepo,
+		InvoiceRepo:          invoiceRepo,
 	}
 
 	// Run both ledger and billing migrations


### PR DESCRIPTION
## Summary

Integrates billing with the hosted checkout service: an issued invoice can be collected through a `pay.stawi.org` session, and settlement only happens from a server-side-verified completed session.

- `CheckoutIntegration` business unit: `CreateInvoiceCheckout` (session with order_ref = invoice id, exact Money from the invoice total, payer profile prefilled) and `SettleFromCheckout` (verified-completed session → `RecordPayment`), exposed via `BillingWorkflow.CollectInvoice`/`SettleInvoiceFromCheckout`
- Safety: settlement is idempotent (already-PAID → no-op), amount+currency must match the invoice exactly (loud mismatch error), invoice identity from the session's server-side `order_ref` never client input, strict `moneyFromDecimal` (rejects >2dp instead of rounding money)
- Config + main wiring: checkout Connect client with audience `service_payment_checkout` (tenancy backfill: service-authentication#723, already rolled out)
- Contract tests run billing's real Postgres-backed invoice engine against the REAL checkout Connect handler over httptest: creation mapping, settle happy path, idempotent re-settle, not-completed rejection, amount-mismatch rejection

Follow-up (post-BSR publish): expose `CollectInvoicePayment` as a billing RPC.