### PR TITLE
feat(pawapay): RFC-9421 request signing for financial requests

### DIFF
--- a/apps/integrations/pawapay/config/config.go
+++ b/apps/integrations/pawapay/config/config.go
@@ -30,6 +30,10 @@ const (
 	HeaderProvider = "X-PAWAPAY_PROVIDER"
 	// HeaderCountry is the header for the default ISO 3166-1 alpha-3 country code.
 	HeaderCountry = "X-PAWAPAY_COUNTRY"
+	// HeaderSignatureKeyID is the header for the RFC-9421 signing key identifier.
+	HeaderSignatureKeyID = "X-PAWAPAY_SIGNATURE_KEY_ID"
+	// HeaderPrivateKeyPEM is the header for the PEM-encoded ECDSA P-256 private key.
+	HeaderPrivateKeyPEM = "X-PAWAPAY_PRIVATE_KEY_PEM"
 )
 
 type PawapayConfig struct {
@@ -56,6 +60,15 @@ type PawapayConfig struct {
 
 	// Environment: sandbox or production
 	Environment string `envDefault:"sandbox" env:"PAWAPAY_ENVIRONMENT"`
+
+	// SignatureKeyID is the key identifier used in RFC-9421 request signing.
+	// When both SignatureKeyID and PrivateKeyPEM are set, financial POST
+	// requests are signed before sending.
+	SignatureKeyID string `env:"PAWAPAY_SIGNATURE_KEY_ID"`
+
+	// PrivateKeyPEM is the PEM-encoded ECDSA P-256 private key for
+	// RFC-9421 request signing.
+	PrivateKeyPEM string `env:"PAWAPAY_PRIVATE_KEY_PEM"`
 
 	// Queue configuration - payment queue for payouts (disbursements)
 	QueuePaymentName string `envDefault:"pawapay.payments.dequeue"       env:"QUEUE_PAWAPAY_PAYMENT_NAME"`

--- a/apps/integrations/pawapay/service/client/client.go
+++ b/apps/integrations/pawapay/service/client/client.go
@@ -17,11 +17,13 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/antinvestor/service-payments/pkg/integrationobs"
@@ -33,6 +35,11 @@ const httpTimeout = 30 * time.Second
 type client struct {
 	httpClient *http.Client
 	metrics    *integrationobs.Metrics
+
+	// keyCache caches parsed ECDSA private keys keyed by keyID to avoid
+	// re-parsing PEM on every request (mirrors mpesa token caching pattern).
+	keyMu    sync.RWMutex
+	keyCache map[string]*ecdsa.PrivateKey
 }
 
 // NewClient creates a new pawaPay Merchant API v2 client.
@@ -41,8 +48,31 @@ func NewClient() PawapayClient {
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
 		},
-		metrics: integrationobs.NewMetrics("pawapay"),
+		metrics:  integrationobs.NewMetrics("pawapay"),
+		keyCache: make(map[string]*ecdsa.PrivateKey),
 	}
+}
+
+// cachedKey returns the parsed ECDSA key for keyID, parsing and caching it
+// from pemData on the first call. Errors if pemData is invalid or non-P256.
+func (c *client) cachedKey(keyID, pemData string) (*ecdsa.PrivateKey, error) {
+	c.keyMu.RLock()
+	if k, ok := c.keyCache[keyID]; ok {
+		c.keyMu.RUnlock()
+		return k, nil
+	}
+	c.keyMu.RUnlock()
+
+	k, err := parsePrivateKey(pemData)
+	if err != nil {
+		return nil, err
+	}
+
+	c.keyMu.Lock()
+	c.keyCache[keyID] = k
+	c.keyMu.Unlock()
+
+	return k, nil
 }
 
 // doRequest performs an authenticated JSON request against the pawaPay API
@@ -64,13 +94,17 @@ func (c *client) doRequest(
 	logger := util.Log(ctx).WithField("type", logType)
 	defer logger.Release()
 
-	var body io.Reader
+	var (
+		rawBody []byte
+		body    io.Reader
+	)
 	if payload != nil {
-		raw, err := json.Marshal(payload)
+		var err error
+		rawBody, err = json.Marshal(payload)
 		if err != nil {
 			return fmt.Errorf("marshal %s payload: %w", logType, err)
 		}
-		body = bytes.NewReader(raw)
+		body = bytes.NewReader(rawBody)
 	}
 
 	apiURL := creds.ResolveBaseURL() + endpoint
@@ -82,6 +116,19 @@ func (c *client) doRequest(
 	httpReq.Header.Set("Authorization", "Bearer "+creds.APIToken)
 	if payload != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	// RFC-9421 request signing: only for POST requests with a body and when
+	// signing credentials are configured. A configured-but-broken key must
+	// not silently send unsigned financial requests.
+	if payload != nil && creds.SignatureKeyID != "" && creds.PrivateKeyPEM != "" {
+		key, keyErr := c.cachedKey(creds.SignatureKeyID, creds.PrivateKeyPEM)
+		if keyErr != nil {
+			return fmt.Errorf("parse signing key for %s: %w", logType, keyErr)
+		}
+		if signErr := signRequest(httpReq, rawBody, creds.SignatureKeyID, key, time.Now()); signErr != nil {
+			return fmt.Errorf("sign %s request: %w", logType, signErr)
+		}
 	}
 
 	resp, err := c.httpClient.Do(httpReq)

--- a/apps/integrations/pawapay/service/client/client_test.go
+++ b/apps/integrations/pawapay/service/client/client_test.go
@@ -16,7 +16,14 @@ package client_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,6 +32,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testKeyPair generates a P-256 PKCS#8 PEM private key for signing tests.
+func testKeyPair(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return key, string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// testCredsWithSigning builds Credentials with signing key set.
+func testCredsWithSigning(serverURL, keyID, pemStr string) *client.Credentials {
+	return &client.Credentials{
+		APIToken:       "TEST_API_TOKEN",
+		Environment:    "sandbox",
+		BaseURL:        serverURL,
+		SignatureKeyID: keyID,
+		PrivateKeyPEM:  pemStr,
+	}
+}
 
 func testCreds(serverURL string) *client.Credentials {
 	return &client.Credentials{
@@ -545,4 +573,106 @@ func TestAvailability(t *testing.T) {
 	require.Len(t, resp, 1)
 	require.Len(t, resp[0].Providers, 1)
 	assert.Equal(t, "DELAYED", resp[0].Providers[0].OperationTypes[1].Status)
+}
+
+// ─── Signing integration tests ────────────────────────────────────────────────
+
+// TestInitiatePayout_WithSigning verifies that when signing credentials are
+// present the four RFC-9421 headers are emitted and the Content-Digest
+// matches the body received by the server.
+func TestInitiatePayout_WithSigning(t *testing.T) {
+	_, pemStr := testKeyPair(t)
+
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture raw body before decoding
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		receivedBody = buf
+
+		// All four signing headers must be present
+		assert.NotEmpty(t, r.Header.Get("Content-Digest"), "Content-Digest must be set")
+		assert.NotEmpty(t, r.Header.Get("Signature-Date"), "Signature-Date must be set")
+		assert.NotEmpty(t, r.Header.Get("Signature-Input"), "Signature-Input must be set")
+		assert.NotEmpty(t, r.Header.Get("Signature"), "Signature must be set")
+
+		// Content-Digest must match the received body
+		sum := sha256.Sum256(receivedBody)
+		expectedDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(sum[:]) + ":"
+		assert.Equal(t, expectedDigest, r.Header.Get("Content-Digest"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"payoutId":"f4401bd2","status":"ACCEPTED","created":"2020-10-19T11:17:01Z"}`))
+	}))
+	defer server.Close()
+
+	pawapayCli := client.NewClient()
+	resp, err := pawapayCli.InitiatePayout(
+		context.Background(),
+		testCredsWithSigning(server.URL, "TEST_KEY_ID", pemStr),
+		&client.PayoutRequest{
+			PayoutID:    "f4401bd2",
+			Amount:      "100",
+			Currency:    "ZMW",
+			PhoneNumber: "260763456789",
+			Provider:    "MTN_MOMO_ZMB",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, client.InitiationStatusAccepted, resp.Status)
+}
+
+// TestInitiatePayout_NoSigning confirms that when no signing credentials are
+// configured the four headers are absent.
+func TestInitiatePayout_NoSigning(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Content-Digest"), "Content-Digest must not be set without signing creds")
+		assert.Empty(t, r.Header.Get("Signature-Input"), "Signature-Input must not be set without signing creds")
+		assert.Empty(t, r.Header.Get("Signature"), "Signature must not be set without signing creds")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"payoutId":"f4401bd2","status":"ACCEPTED","created":"2020-10-19T11:17:01Z"}`))
+	}))
+	defer server.Close()
+
+	pawapayCli := client.NewClient()
+	resp, err := pawapayCli.InitiatePayout(
+		context.Background(),
+		testCreds(server.URL), // no signing fields
+		&client.PayoutRequest{
+			PayoutID:    "f4401bd2",
+			Amount:      "100",
+			Currency:    "ZMW",
+			PhoneNumber: "260763456789",
+			Provider:    "MTN_MOMO_ZMB",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, client.InitiationStatusAccepted, resp.Status)
+}
+
+// TestInitiatePayout_InvalidPEM confirms that a configured-but-broken key
+// causes InitiatePayout to return an error without hitting the server.
+func TestInitiatePayout_InvalidPEM(t *testing.T) {
+	hitServer := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitServer = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	pawapayCli := client.NewClient()
+	_, err := pawapayCli.InitiatePayout(
+		context.Background(),
+		testCredsWithSigning(server.URL, "BAD_KEY", "not-a-pem"),
+		&client.PayoutRequest{
+			PayoutID:    "f4401bd2",
+			Amount:      "100",
+			Currency:    "ZMW",
+			PhoneNumber: "260763456789",
+			Provider:    "MTN_MOMO_ZMB",
+		},
+	)
+	require.Error(t, err, "invalid PEM must return an error")
+	assert.False(t, hitServer, "no request must reach the server when key parsing fails")
 }

--- a/apps/integrations/pawapay/service/client/models.go
+++ b/apps/integrations/pawapay/service/client/models.go
@@ -52,6 +52,15 @@ type Credentials struct {
 	Provider string
 	// Country is an optional default ISO 3166-1 alpha-3 country code.
 	Country string
+	// SignatureKeyID is the key identifier used in RFC-9421 request signing.
+	// When both SignatureKeyID and PrivateKeyPEM are set, financial POST
+	// requests are signed with the ECDSA-P256 key before sending.
+	SignatureKeyID string
+	// PrivateKeyPEM is the PEM-encoded ECDSA P-256 private key used for
+	// RFC-9421 request signing. Accepts PKCS#8 ("PRIVATE KEY") and
+	// SEC1 ("EC PRIVATE KEY") PEM blocks. Optional; only used when
+	// SignatureKeyID is also set.
+	PrivateKeyPEM string
 }
 
 // ResolveBaseURL returns the pawaPay API base URL for these credentials.

--- a/apps/integrations/pawapay/service/client/signer.go
+++ b/apps/integrations/pawapay/service/client/signer.go
@@ -1,0 +1,163 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	sigLabel = "sig-pp"
+	sigAlg   = "ecdsa-p256-sha256"
+
+	// sigDuration is how long a signed request is valid.
+	sigDuration = 60
+
+	// ecdsaPartLen is the fixed byte length of each ECDSA component (r or s)
+	// for P-256 (256 bits / 8 = 32 bytes).
+	ecdsaPartLen = 32
+
+	// ecdsaSigLen is the total length of the concatenated r||s signature bytes.
+	ecdsaSigLen = ecdsaPartLen * 2
+)
+
+// signRequest adds RFC-9421 message-signature headers (Content-Digest,
+// Signature-Date, Signature-Input, Signature) so pawaPay can verify the
+// integrity and origin of the data we send. Only called when signing
+// credentials are configured.
+func signRequest(req *http.Request, body []byte, keyID string, key *ecdsa.PrivateKey, now time.Time) error {
+	// Content-Digest: sha-256=:<base64(sha256(body))>:
+	sum := sha256.Sum256(body)
+	digest := "sha-256=:" + base64.StdEncoding.EncodeToString(sum[:]) + ":"
+
+	// Signature-Date: RFC3339 UTC
+	sigDate := now.UTC().Format(time.RFC3339Nano)
+
+	created := now.Unix()
+	expires := created + sigDuration
+
+	authority := req.URL.Host
+	path := req.URL.Path
+
+	// Signature-Input structured field
+	sigParams := fmt.Sprintf(
+		`("%s" "%s" "%s" "signature-date" "content-digest" "content-type");alg="%s";keyid="%s";created=%d;expires=%d`,
+		"@method", "@authority", "@path",
+		sigAlg, keyID, created, expires,
+	)
+	sigInput := sigLabel + "=" + sigParams
+
+	// Build signature base per RFC 9421 §2.5
+	base := buildSignatureBase(req.Method, authority, path, sigDate, digest, req.Header.Get("Content-Type"), sigParams)
+
+	// Sign: ECDSA-P256 over SHA-256(base) → 64-byte r||s
+	h := sha256.Sum256([]byte(base))
+	r, s, err := ecdsa.Sign(rand.Reader, key, h[:])
+	if err != nil {
+		return fmt.Errorf("ecdsa sign: %w", err)
+	}
+
+	// Encode as fixed-width 64-byte r||s (RFC 9421 requirement)
+	rBytes := zeroPad(r, ecdsaPartLen)
+	rawSig := make([]byte, ecdsaSigLen)
+	copy(rawSig[:ecdsaPartLen], rBytes)
+	copy(rawSig[ecdsaPartLen:], zeroPad(s, ecdsaPartLen))
+	sigValue := sigLabel + "=:" + base64.StdEncoding.EncodeToString(rawSig) + ":"
+
+	// Set headers
+	req.Header.Set("Content-Digest", digest)
+	req.Header.Set("Signature-Date", sigDate)
+	req.Header.Set("Signature-Input", sigInput)
+	req.Header.Set("Signature", sigValue)
+
+	return nil
+}
+
+// buildSignatureBase constructs the RFC 9421 §2.5 signature base string.
+// Lines are joined with \n; there is NO trailing newline.
+func buildSignatureBase(method, authority, path, sigDate, digest, contentType, sigParams string) string {
+	lines := []string{
+		`"@method": ` + method,
+		`"@authority": ` + authority,
+		`"@path": ` + path,
+		`"signature-date": ` + sigDate,
+		`"content-digest": ` + digest,
+		`"content-type": ` + contentType,
+		`"@signature-params": ` + sigParams,
+	}
+	return strings.Join(lines, "\n")
+}
+
+// zeroPad returns the big.Int's bytes left-padded with zeros to length n.
+func zeroPad(n *big.Int, length int) []byte {
+	b := n.Bytes()
+	if len(b) >= length {
+		return b[len(b)-length:]
+	}
+	padded := make([]byte, length)
+	copy(padded[length-len(b):], b)
+	return padded
+}
+
+// parsePrivateKey parses a PEM-encoded ECDSA private key.
+// Accepted PEM types: "PRIVATE KEY" (PKCS#8) and "EC PRIVATE KEY" (SEC1).
+// Returns an error if the key is not on the P-256 curve.
+func parsePrivateKey(pemData string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, errors.New("pawapay signer: no PEM block found in private key")
+	}
+
+	var ecKey *ecdsa.PrivateKey
+
+	switch block.Type {
+	case "PRIVATE KEY": // PKCS#8
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("pawapay signer: parse PKCS#8 key: %w", err)
+		}
+		var ok bool
+		ecKey, ok = key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("pawapay signer: PKCS#8 key is not an ECDSA key")
+		}
+	case "EC PRIVATE KEY": // SEC1
+		var err error
+		ecKey, err = x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("pawapay signer: parse SEC1 EC key: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("pawapay signer: unsupported PEM block type %q", block.Type)
+	}
+
+	if ecKey.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("pawapay signer: key curve %s is not P-256", ecKey.Curve.Params().Name)
+	}
+
+	return ecKey, nil
+}

--- a/apps/integrations/pawapay/service/client/signer_test.go
+++ b/apps/integrations/pawapay/service/client/signer_test.go
@@ -1,0 +1,309 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client //nolint:testpackage // white-box tests: need access to unexported signRequest, buildSignatureBase, parsePrivateKey
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// generateP256Key generates a fresh P-256 key for tests.
+func generateP256Key(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return key
+}
+
+// generateP384Key generates a P-384 key to test curve rejection.
+func generateP384Key(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	return key
+}
+
+// marshalPKCS8PEM encodes key as PKCS#8 PEM.
+func marshalPKCS8PEM(t *testing.T, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// marshalSEC1PEM encodes key as SEC1 PEM.
+func marshalSEC1PEM(t *testing.T, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+}
+
+// makeRequest builds an *http.Request for use in tests.
+func makeRequest(t *testing.T, rawURL string, body []byte) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// ─── Content-Digest ──────────────────────────────────────────────────────────
+
+func TestContentDigest(t *testing.T) {
+	body := []byte(`{"depositId":"8917c345","amount":"15","currency":"ZMW"}`)
+	sum := sha256.Sum256(body)
+	expected := "sha-256=:" + base64.StdEncoding.EncodeToString(sum[:]) + ":"
+
+	key := generateP256Key(t)
+	req := makeRequest(t, "https://api.sandbox.pawapay.io/v2/deposits", body)
+
+	err := signRequest(req, body, "TEST_KEY", key, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, expected, req.Header.Get("Content-Digest"))
+}
+
+// ─── Signature base golden test ───────────────────────────────────────────────
+
+func TestBuildSignatureBase_Golden(t *testing.T) {
+	// Fixed inputs so we get a deterministic base.
+	method := "POST"
+	authority := "api.sandbox.pawapay.io"
+	path := "/v2/deposits"
+	sigDate := "2024-05-02T15:36:45.058799Z"
+	digest := "sha-256=:abc123=:"
+	contentType := "application/json"
+	keyID := "TEST_KEY"
+	created := int64(1714660605)
+	expires := created + 60
+	sigParams := `("@method" "@authority" "@path" "signature-date" "content-digest" "content-type");alg="ecdsa-p256-sha256";keyid="TEST_KEY";created=1714660605;expires=1714660665`
+
+	want := strings.Join([]string{
+		`"@method": POST`,
+		`"@authority": api.sandbox.pawapay.io`,
+		`"@path": /v2/deposits`,
+		`"signature-date": 2024-05-02T15:36:45.058799Z`,
+		`"content-digest": sha-256=:abc123=:`,
+		`"content-type": application/json`,
+		`"@signature-params": ("@method" "@authority" "@path" "signature-date" "content-digest" "content-type");alg="ecdsa-p256-sha256";keyid="TEST_KEY";created=1714660605;expires=1714660665`,
+	}, "\n")
+
+	got := buildSignatureBase(method, authority, path, sigDate, digest, contentType, sigParams)
+	assert.Equal(t, want, got)
+
+	// No trailing newline
+	assert.False(t, strings.HasSuffix(got, "\n"), "signature base must not have a trailing newline")
+
+	// Sanity: all seven lines
+	assert.Equal(t, 7, strings.Count(got, "\n")+1)
+
+	_ = keyID
+	_ = expires
+}
+
+// ─── Round-trip verification ─────────────────────────────────────────────────
+
+func TestSignRequest_RoundTrip(t *testing.T) {
+	body := []byte(`{"payoutId":"f4401bd2","amount":"100","currency":"ZMW"}`)
+	key := generateP256Key(t)
+	now := time.Unix(1714660605, 0).UTC()
+
+	req := makeRequest(t, "https://api.sandbox.pawapay.io/v2/payouts", body)
+	err := signRequest(req, body, "MY_KEY", key, now)
+	require.NoError(t, err)
+
+	// --- reconstruct the base from emitted headers ---
+	digest := req.Header.Get("Content-Digest")
+	sigDate := req.Header.Get("Signature-Date")
+	sigInputFull := req.Header.Get("Signature-Input") // "sig-pp=(...)"
+
+	require.NotEmpty(t, digest)
+	require.NotEmpty(t, sigDate)
+	require.NotEmpty(t, sigInputFull)
+
+	// Strip "sig-pp=" prefix to get just the params part
+	sigParams := strings.TrimPrefix(sigInputFull, sigLabel+"=")
+
+	base := buildSignatureBase(
+		req.Method,
+		req.URL.Host,
+		req.URL.Path,
+		sigDate,
+		digest,
+		req.Header.Get("Content-Type"),
+		sigParams,
+	)
+
+	// Decode the 64-byte r||s signature
+	sigFull := req.Header.Get("Signature")
+	require.NotEmpty(t, sigFull)
+	// Strip "sig-pp=:" prefix and ":" suffix
+	sigB64 := strings.TrimPrefix(sigFull, sigLabel+"=:")
+	sigB64 = strings.TrimSuffix(sigB64, ":")
+	rawSig, err := base64.StdEncoding.DecodeString(sigB64)
+	require.NoError(t, err)
+	require.Len(t, rawSig, 64, "signature must be exactly 64 bytes (r||s)")
+
+	r := new(big.Int).SetBytes(rawSig[:32])
+	s := new(big.Int).SetBytes(rawSig[32:])
+
+	h := sha256.Sum256([]byte(base))
+	assert.True(t, ecdsa.Verify(&key.PublicKey, h[:], r, s), "signature verification must pass")
+}
+
+func TestSignRequest_TamperedBodyFails(t *testing.T) {
+	originalBody := []byte(`{"payoutId":"f4401bd2","amount":"100","currency":"ZMW"}`)
+	tamperedBody := []byte(`{"payoutId":"f4401bd2","amount":"999","currency":"ZMW"}`)
+
+	key := generateP256Key(t)
+	now := time.Unix(1714660605, 0).UTC()
+
+	req := makeRequest(t, "https://api.sandbox.pawapay.io/v2/payouts", originalBody)
+	err := signRequest(req, originalBody, "MY_KEY", key, now)
+	require.NoError(t, err)
+
+	// Decode original signature
+	sigFull := req.Header.Get("Signature")
+	sigB64 := strings.TrimPrefix(sigFull, sigLabel+"=:")
+	sigB64 = strings.TrimSuffix(sigB64, ":")
+	rawSig, err := base64.StdEncoding.DecodeString(sigB64)
+	require.NoError(t, err)
+	r := new(big.Int).SetBytes(rawSig[:32])
+	s := new(big.Int).SetBytes(rawSig[32:])
+
+	// Reconstruct signature base with tampered digest
+	tamperedSum := sha256.Sum256(tamperedBody)
+	tamperedDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(tamperedSum[:]) + ":"
+	sigParams := strings.TrimPrefix(req.Header.Get("Signature-Input"), sigLabel+"=")
+
+	tamperedBase := buildSignatureBase(
+		req.Method, req.URL.Host, req.URL.Path,
+		req.Header.Get("Signature-Date"),
+		tamperedDigest,
+		req.Header.Get("Content-Type"),
+		sigParams,
+	)
+
+	// Verification against tampered base must fail
+	h := sha256.Sum256([]byte(tamperedBase))
+	assert.False(t, ecdsa.Verify(&key.PublicKey, h[:], r, s), "tampered body must not verify")
+}
+
+// ─── Signature-Input format ──────────────────────────────────────────────────
+
+var sigInputPattern = regexp.MustCompile(
+	`^sig-pp=\("@method" "@authority" "@path" "signature-date" "content-digest" "content-type"\);` +
+		`alg="ecdsa-p256-sha256";keyid="[^"]+";created=\d+;expires=\d+$`,
+)
+
+func TestSignRequest_SignatureInputFormat(t *testing.T) {
+	body := []byte(`{"test":true}`)
+	key := generateP256Key(t)
+	req := makeRequest(t, "https://api.sandbox.pawapay.io/v2/deposits", body)
+
+	err := signRequest(req, body, "MY_KEY_ID", key, time.Now())
+	require.NoError(t, err)
+
+	sigInput := req.Header.Get("Signature-Input")
+	assert.Regexp(t, sigInputPattern, sigInput, "Signature-Input does not match expected format")
+
+	// created < expires
+	// extract created and expires via simple string parsing to keep test simple
+	assert.Contains(t, sigInput, `keyid="MY_KEY_ID"`)
+	createdIdx := strings.Index(sigInput, "created=")
+	expiresIdx := strings.Index(sigInput, "expires=")
+	require.True(t, createdIdx > 0 && expiresIdx > 0)
+	var created, expires int64
+	_, errC := fmt.Sscanf(sigInput[createdIdx:], "created=%d", &created)
+	_, errE := fmt.Sscanf(sigInput[expiresIdx:], "expires=%d", &expires)
+	require.NoError(t, errC)
+	require.NoError(t, errE)
+	assert.Less(t, created, expires, "created must be < expires")
+	assert.Equal(t, int64(sigDuration), expires-created)
+}
+
+// ─── parsePrivateKey ─────────────────────────────────────────────────────────
+
+// keyDER encodes key as PKCS#8 DER for identity comparison.
+func keyDER(t *testing.T, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return der
+}
+
+func TestParsePrivateKey_PKCS8(t *testing.T) {
+	key := generateP256Key(t)
+	pemStr := marshalPKCS8PEM(t, key)
+
+	parsed, err := parsePrivateKey(pemStr)
+	require.NoError(t, err)
+	assert.Equal(t, keyDER(t, key), keyDER(t, parsed), "parsed key must match original")
+}
+
+func TestParsePrivateKey_SEC1(t *testing.T) {
+	key := generateP256Key(t)
+	pemStr := marshalSEC1PEM(t, key)
+
+	parsed, err := parsePrivateKey(pemStr)
+	require.NoError(t, err)
+	assert.Equal(t, keyDER(t, key), keyDER(t, parsed))
+}
+
+func TestParsePrivateKey_P384Rejected(t *testing.T) {
+	key := generateP384Key(t)
+	pemStr := marshalPKCS8PEM(t, key)
+
+	_, err := parsePrivateKey(pemStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "P-256")
+}
+
+func TestParsePrivateKey_GarbageRejected(t *testing.T) {
+	_, err := parsePrivateKey("not a pem block at all")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM block")
+}
+
+func TestParsePrivateKey_WrongPEMType(t *testing.T) {
+	garbage := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte("fake"),
+	}))
+	_, err := parsePrivateKey(garbage)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported PEM block type")
+}

--- a/apps/integrations/pawapay/service/credentials/resolver.go
+++ b/apps/integrations/pawapay/service/credentials/resolver.go
@@ -57,10 +57,12 @@ func (r *Resolver) FromHeaders(ctx context.Context, headers map[string]string) (
 	}
 
 	creds := &client.Credentials{
-		APIToken:    headerOrDefault(headers, config.HeaderAPIToken, r.cfg.APIToken),
-		Environment: headerOrDefault(headers, config.HeaderEnvironment, r.cfg.Environment),
-		Provider:    headerOrDefault(headers, config.HeaderProvider, r.cfg.Provider),
-		Country:     headerOrDefault(headers, config.HeaderCountry, r.cfg.Country),
+		APIToken:       headerOrDefault(headers, config.HeaderAPIToken, r.cfg.APIToken),
+		Environment:    headerOrDefault(headers, config.HeaderEnvironment, r.cfg.Environment),
+		Provider:       headerOrDefault(headers, config.HeaderProvider, r.cfg.Provider),
+		Country:        headerOrDefault(headers, config.HeaderCountry, r.cfg.Country),
+		SignatureKeyID: headerOrDefault(headers, config.HeaderSignatureKeyID, r.cfg.SignatureKeyID),
+		PrivateKeyPEM:  headerOrDefault(headers, config.HeaderPrivateKeyPEM, r.cfg.PrivateKeyPEM),
 	}
 
 	if creds.APIToken == "" {
@@ -97,10 +99,12 @@ func (r *Resolver) FromConnection(ctx context.Context, connection string) (*clie
 	}
 
 	creds := &client.Credentials{
-		APIToken:    credMap[config.HeaderAPIToken],
-		Environment: credMap[config.HeaderEnvironment],
-		Provider:    credMap[config.HeaderProvider],
-		Country:     credMap[config.HeaderCountry],
+		APIToken:       credMap[config.HeaderAPIToken],
+		Environment:    credMap[config.HeaderEnvironment],
+		Provider:       credMap[config.HeaderProvider],
+		Country:        credMap[config.HeaderCountry],
+		SignatureKeyID: credMap[config.HeaderSignatureKeyID],
+		PrivateKeyPEM:  credMap[config.HeaderPrivateKeyPEM],
 	}
 
 	if creds.APIToken == "" {
@@ -117,10 +121,12 @@ func (r *Resolver) Default() (*client.Credentials, error) {
 		return nil, ErrMissingAPIToken
 	}
 	return &client.Credentials{
-		APIToken:    r.cfg.APIToken,
-		Environment: r.cfg.Environment,
-		Provider:    r.cfg.Provider,
-		Country:     r.cfg.Country,
+		APIToken:       r.cfg.APIToken,
+		Environment:    r.cfg.Environment,
+		Provider:       r.cfg.Provider,
+		Country:        r.cfg.Country,
+		SignatureKeyID: r.cfg.SignatureKeyID,
+		PrivateKeyPEM:  r.cfg.PrivateKeyPEM,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Implements pawaPay's RFC-9421 HTTP Message Signatures on outbound financial requests (deposits, payouts, bulk payouts, refunds, resend/cancel POSTs) so pawaPay can cryptographically verify the integrity and origin of the data we send — the outbound mirror of our verify-by-lookup callback handling.

- `Content-Digest` (sha-256 structured field), `Signature-Date` (RFC3339 UTC), `Signature-Input`/`Signature` with label `sig-pp`, components `("@method" "@authority" "@path" "signature-date" "content-digest" "content-type")`, `alg="ecdsa-p256-sha256"`, `created`/`expires` (+60s)
- Signature bytes are the RFC-9421 fixed-width 64-byte `r||s` form (not DER); keys parsed from PKCS#8 or SEC1 PEM, non-P256 rejected; parsed keys cached per keyid
- Activates only when `PAWAPAY_SIGNATURE_KEY_ID` + `PAWAPAY_PRIVATE_KEY_PEM` are configured (env, headers, or per-tenant settings); a configured-but-broken key FAILS the request rather than silently sending unsigned
- Tests: exact Content-Digest, golden signature base, sign→`ecdsa.Verify` round trip incl. tamper detection, Signature-Input format, PEM parsing matrix, and client-level assertions that all four headers reach the wire (and don't when unconfigured)

Activation: generate a P-256 keypair, upload the public key on the pawaPay dashboard (API tokens → signatures), seed the private key + key id (Vault → settings/env), optionally enable "signed requests only" on the account.