### PR TITLE
feat(checkout): redirect-based card method (polar hosted checkout)

### DIFF
--- a/apps/checkout/config/config.go
+++ b/apps/checkout/config/config.go
@@ -40,5 +40,5 @@ type CheckoutConfig struct {
 
 	// MethodsJSON is the v1 method registry: which payment methods the page
 	// renders and the prompt route hint each maps to.
-	MethodsJSON string `env:"CHECKOUT_METHODS" envDefault:"[{\"key\":\"mpesa\",\"name\":\"M-PESA\",\"route\":\"mpesa\",\"prefixes\":[\"254\"],\"currencies\":[\"KES\"]},{\"key\":\"mtn_momo\",\"name\":\"MTN MoMo\",\"route\":\"mtn\",\"prefixes\":[\"256\",\"260\"],\"currencies\":[\"UGX\",\"ZMW\"]},{\"key\":\"airtel_money\",\"name\":\"Airtel Money\",\"route\":\"airtel\",\"prefixes\":[\"255\",\"256\"],\"currencies\":[\"TZS\",\"UGX\"]},{\"key\":\"pawapay\",\"name\":\"Mobile Money\",\"route\":\"pawapay\",\"prefixes\":[],\"currencies\":[]}]"`
+	MethodsJSON string `env:"CHECKOUT_METHODS" envDefault:"[{\"key\":\"mpesa\",\"name\":\"M-PESA\",\"route\":\"mpesa\",\"prefixes\":[\"254\"],\"currencies\":[\"KES\"]},{\"key\":\"mtn_momo\",\"name\":\"MTN MoMo\",\"route\":\"mtn\",\"prefixes\":[\"256\",\"260\"],\"currencies\":[\"UGX\",\"ZMW\"]},{\"key\":\"airtel_money\",\"name\":\"Airtel Money\",\"route\":\"airtel\",\"prefixes\":[\"255\",\"256\"],\"currencies\":[\"TZS\",\"UGX\"]},{\"key\":\"pawapay\",\"name\":\"Mobile Money\",\"route\":\"pawapay\",\"prefixes\":[],\"currencies\":[]},{\"key\":\"card\",\"name\":\"Card\",\"route\":\"polar\",\"prefixes\":[],\"currencies\":[],\"redirect\":true}]"`
 }

--- a/apps/checkout/service/business/checkout.go
+++ b/apps/checkout/service/business/checkout.go
@@ -553,12 +553,18 @@ func (b *CheckoutBusiness) Pay(
 		return nil, err
 	}
 
-	// Resolve msisdn and contactRef
-	msisdn, contactID, payerErr := b.resolvePayer(session, in)
-	if payerErr != nil {
-		b.obs.RecordPayFailure(ctx, "contact_required")
-		err = payerErr
-		return nil, err
+	// Resolve msisdn and contactRef.
+	// Redirect methods (e.g. card/polar) do not require a phone number — the
+	// provider handles identity at its own hosted page.
+	var msisdn, contactID string
+	if !method.Redirect {
+		var payerErr error
+		msisdn, contactID, payerErr = b.resolvePayer(session, in)
+		if payerErr != nil {
+			b.obs.RecordPayFailure(ctx, "contact_required")
+			err = payerErr
+			return nil, err
+		}
 	}
 
 	// All guards passed — record the attempt.
@@ -772,6 +778,12 @@ func (b *CheckoutBusiness) RefreshStatus(
 	}
 
 	status := resp.Msg.GetStatus()
+
+	// Capture redirect URL emitted by redirect-method providers (e.g. polar) while processing.
+	if status != commonv1.STATUS_SUCCESSFUL && status != commonv1.STATUS_FAILED {
+		b.captureRedirectURL(ctx, session, resp.Msg.GetExtras())
+	}
+
 	//nolint:exhaustive // Only terminal statuses need action; all others leave session unchanged.
 	switch status {
 	case commonv1.STATUS_SUCCESSFUL:
@@ -811,6 +823,37 @@ func (b *CheckoutBusiness) RefreshStatus(
 		b.obs.RecordOutcomeFailed(ctx)
 	}
 	return session, nil
+}
+
+// captureRedirectURL extracts a "checkout_url" from the provider extras and persists it
+// on the session as Metadata["_redirect_url"] when the URL changes.  The write is
+// idempotent and a failure is logged but not propagated.
+func (b *CheckoutBusiness) captureRedirectURL(
+	ctx context.Context,
+	session *models.CheckoutSession,
+	extras *structpb.Struct,
+) {
+	if extras == nil {
+		return
+	}
+	field, ok := extras.GetFields()["checkout_url"]
+	if !ok {
+		return
+	}
+	urlStr := field.GetStringValue()
+	if urlStr == "" || !IsSafeReturnURL(urlStr) {
+		return
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]any)
+	}
+	if existing, _ := session.Metadata["_redirect_url"].(string); existing == urlStr {
+		return // already persisted — no-op
+	}
+	session.Metadata["_redirect_url"] = urlStr
+	if _, updateErr := b.sessionRepo.Update(ctx, session); updateErr != nil {
+		util.Log(ctx).WithError(updateErr).Warn("could not persist redirect url on session")
+	}
 }
 
 // writeClues persists checkout clues to the payer's profile (best-effort).

--- a/apps/checkout/service/business/checkout_test.go
+++ b/apps/checkout/service/business/checkout_test.go
@@ -1644,3 +1644,250 @@ func TestRefreshStatus_NilWorkMan_AsyncFallback_NoPanic(t *testing.T) {
 	require.NotNil(t, profCli.updateReq)
 	assert.Equal(t, "profile-nwm", profCli.updateReq.GetId())
 }
+
+// ---------------------------------------------------------------------------
+// Redirect method tests
+// ---------------------------------------------------------------------------
+
+// redirectRegistry returns a registry that includes the card redirect method.
+func redirectRegistry() *business.MethodRegistry {
+	reg, err := business.ParseMethodRegistry(
+		`[{"key":"mpesa","name":"M-PESA","route":"mpesa","prefixes":["254"],"currencies":["KES"]},` +
+			`{"key":"card","name":"Card","route":"polar","prefixes":[],"currencies":[],"redirect":true}]`,
+	)
+	if err != nil {
+		panic(err)
+	}
+	return reg
+}
+
+// 10a. Pay with redirect method + no phone/contact: prompt sent, Source.ContactId is empty, Route == "polar".
+func TestPay_RedirectMethod_NoPhoneRequired(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+	payCli := &fakePaymentClient{}
+	b := newBusiness(
+		defaultConfig(),
+		redirectRegistry(),
+		sessionRepo,
+		linkRepo,
+		payCli,
+		&fakeProfileClient{},
+	)
+	ctx := context.Background()
+
+	future := fixedNow().Add(20 * time.Minute)
+	s := &models.CheckoutSession{
+		Ref:          "sess-card",
+		Status:       models.SessionStatusPending,
+		ExpiresAt:    future,
+		Amount:       "100.00",
+		Currency:     "USD",
+		AmountOption: models.AmountOptionFixed,
+		OrderRef:     "ORD-CARD-01",
+	}
+	sessionRepo.sessions["sess-card"] = s
+
+	// No phone, no contact — redirect method does not need them.
+	in := business.PayInput{
+		MethodKey: "card",
+	}
+	updated, err := b.Pay(ctx, "sess-card", in)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	assert.Equal(t, models.SessionStatusProcessing, updated.Status)
+	assert.Equal(t, 1, updated.Attempts)
+
+	// Prompt sent with empty ContactId and correct route.
+	require.NotNil(t, payCli.lastPrompt)
+	assert.Equal(t, "polar", payCli.lastPrompt.GetRoute(), "route must be polar for card method")
+	assert.Empty(t, payCli.lastPrompt.GetSource().GetContactId(), "ContactId must be empty for redirect method")
+}
+
+// 10b. Pay with redirect method and a session that has no PayerProfileID — succeeds (no ErrContactRequired).
+func TestPay_RedirectMethod_NoContactId_NoProfileID_Succeeds(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+	payCli := &fakePaymentClient{}
+	b := newBusiness(
+		defaultConfig(),
+		redirectRegistry(),
+		sessionRepo,
+		linkRepo,
+		payCli,
+		&fakeProfileClient{},
+	)
+	ctx := context.Background()
+
+	future := fixedNow().Add(20 * time.Minute)
+	s := &models.CheckoutSession{
+		Ref:          "sess-card-guest",
+		Status:       models.SessionStatusPending,
+		ExpiresAt:    future,
+		Amount:       "50.00",
+		Currency:     "USD",
+		AmountOption: models.AmountOptionFixed,
+		// No PayerProfileID, no Prefill — anonymous/guest redirect.
+	}
+	sessionRepo.sessions["sess-card-guest"] = s
+
+	in := business.PayInput{
+		MethodKey: "card",
+		// No phone, no contact — must succeed for redirect method.
+	}
+	updated, err := b.Pay(ctx, "sess-card-guest", in)
+	require.NoError(t, err, "redirect method must not require phone or contact")
+	assert.Equal(t, models.SessionStatusProcessing, updated.Status)
+
+	require.NotNil(t, payCli.lastPrompt)
+	assert.Empty(t, payCli.lastPrompt.GetSource().GetContactId())
+	assert.Empty(t, payCli.lastPrompt.GetSource().GetProfileId())
+}
+
+// 10c. Non-redirect method without phone still returns ErrContactRequired (unchanged behaviour).
+func TestPay_NonRedirectMethod_NoPhone_ErrContactRequired(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+	payCli := &fakePaymentClient{}
+	b := newBusiness(
+		defaultConfig(),
+		redirectRegistry(),
+		sessionRepo,
+		linkRepo,
+		payCli,
+		&fakeProfileClient{},
+	)
+	ctx := context.Background()
+
+	future := fixedNow().Add(20 * time.Minute)
+	s := &models.CheckoutSession{
+		Ref:          "sess-mpesa-nophone",
+		Status:       models.SessionStatusPending,
+		ExpiresAt:    future,
+		Amount:       "10.00",
+		Currency:     "KES",
+		AmountOption: models.AmountOptionFixed,
+	}
+	sessionRepo.sessions["sess-mpesa-nophone"] = s
+
+	_, err := b.Pay(ctx, "sess-mpesa-nophone", business.PayInput{
+		MethodKey: "mpesa",
+		// No phone — non-redirect method must still require one.
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, business.ErrContactRequired)
+}
+
+// 11a. RefreshStatus captures checkout_url from extras and persists it as _redirect_url.
+func TestRefreshStatus_CapturesCheckoutURL(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+
+	extras, err := structpb.NewStruct(map[string]any{
+		"checkout_url": "https://polar.sh/checkout/abc123",
+	})
+	require.NoError(t, err)
+
+	payCli := &fakePaymentClient{
+		statusResp: connect.NewResponse(&commonv1.StatusResponse{
+			Status: commonv1.STATUS_IN_PROCESS,
+			Extras: extras,
+		}),
+	}
+	b := newBusiness(defaultConfig(), redirectRegistry(), sessionRepo, linkRepo, payCli, &fakeProfileClient{})
+	ctx := context.Background()
+
+	s := &models.CheckoutSession{
+		Ref:      "sess-redirect-url",
+		Status:   models.SessionStatusProcessing,
+		PromptID: "prompt-polar",
+		Currency: "USD",
+	}
+	sessionRepo.sessions["sess-redirect-url"] = s
+
+	updated, err := b.RefreshStatus(ctx, s)
+	require.NoError(t, err)
+	assert.Equal(t, models.SessionStatusProcessing, updated.Status, "status remains processing")
+
+	// _redirect_url persisted on session metadata.
+	require.NotNil(t, updated.Metadata)
+	assert.Equal(t, "https://polar.sh/checkout/abc123", updated.Metadata["_redirect_url"])
+}
+
+// 11b. RefreshStatus with checkout_url already matching existing — no extra repo update.
+func TestRefreshStatus_CheckoutURL_Idempotent(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+
+	extras, err := structpb.NewStruct(map[string]any{
+		"checkout_url": "https://polar.sh/checkout/already-set",
+	})
+	require.NoError(t, err)
+
+	payCli := &fakePaymentClient{
+		statusResp: connect.NewResponse(&commonv1.StatusResponse{
+			Status: commonv1.STATUS_IN_PROCESS,
+			Extras: extras,
+		}),
+	}
+	b := newBusiness(defaultConfig(), redirectRegistry(), sessionRepo, linkRepo, payCli, &fakeProfileClient{})
+	ctx := context.Background()
+
+	s := &models.CheckoutSession{
+		Ref:      "sess-redirect-idem",
+		Status:   models.SessionStatusProcessing,
+		PromptID: "prompt-polar2",
+		Currency: "USD",
+		Metadata: map[string]any{
+			"_redirect_url": "https://polar.sh/checkout/already-set", // already persisted
+		},
+	}
+	sessionRepo.sessions["sess-redirect-idem"] = s
+	initialCount := sessionRepo.updateCount
+
+	updated, err := b.RefreshStatus(ctx, s)
+	require.NoError(t, err)
+	assert.Equal(t, models.SessionStatusProcessing, updated.Status)
+
+	// No extra update should have been issued since the URL did not change.
+	assert.Equal(t, initialCount, sessionRepo.updateCount, "no extra repo update for unchanged redirect URL")
+}
+
+// 11c. RefreshStatus with javascript: checkout_url — must be ignored (safe-URL check).
+func TestRefreshStatus_CheckoutURL_Unsafe_Ignored(t *testing.T) {
+	sessionRepo := newFakeSessionRepo()
+	linkRepo := newFakeLinkRepo()
+
+	extras, err := structpb.NewStruct(map[string]any{
+		"checkout_url": "javascript:alert(1)",
+	})
+	require.NoError(t, err)
+
+	payCli := &fakePaymentClient{
+		statusResp: connect.NewResponse(&commonv1.StatusResponse{
+			Status: commonv1.STATUS_IN_PROCESS,
+			Extras: extras,
+		}),
+	}
+	b := newBusiness(defaultConfig(), redirectRegistry(), sessionRepo, linkRepo, payCli, &fakeProfileClient{})
+	ctx := context.Background()
+
+	s := &models.CheckoutSession{
+		Ref:      "sess-unsafe-url",
+		Status:   models.SessionStatusProcessing,
+		PromptID: "prompt-unsafe",
+		Currency: "USD",
+	}
+	sessionRepo.sessions["sess-unsafe-url"] = s
+	initialCount := sessionRepo.updateCount
+
+	updated, err := b.RefreshStatus(ctx, s)
+	require.NoError(t, err)
+
+	// Unsafe URL must not be persisted.
+	assert.Equal(t, initialCount, sessionRepo.updateCount, "unsafe URL must not trigger repo update")
+	if updated.Metadata != nil {
+		assert.Empty(t, updated.Metadata["_redirect_url"], "unsafe URL must not be stored")
+	}
+}

--- a/apps/checkout/service/business/methods.go
+++ b/apps/checkout/service/business/methods.go
@@ -28,6 +28,7 @@ type Method struct {
 	Route      string   `json:"route"`
 	Prefixes   []string `json:"prefixes"`
 	Currencies []string `json:"currencies"`
+	Redirect   bool     `json:"redirect"`
 }
 
 // MethodRegistry is the config-defined list of supported methods.
@@ -76,6 +77,8 @@ func (r *MethodRegistry) Get(key string) (Method, bool) {
 }
 
 // Preselect picks the default method: profile clue -> phone prefix -> first.
+// Redirect methods are never selected by phone prefix — only by explicit clue key
+// or as a configured-first fallback when the available list has no non-redirect option.
 // methods must be non-empty.
 func Preselect(methods []Method, clueKey, phoneNumber string) Method {
 	for _, m := range methods {
@@ -86,6 +89,9 @@ func Preselect(methods []Method, clueKey, phoneNumber string) Method {
 	phone := strings.TrimPrefix(strings.TrimSpace(phoneNumber), "+")
 	if phone != "" {
 		for _, m := range methods {
+			if m.Redirect {
+				continue // redirect methods must not be selected by phone prefix
+			}
 			for _, p := range m.Prefixes {
 				if strings.HasPrefix(phone, p) {
 					return m

--- a/apps/checkout/service/business/methods_test.go
+++ b/apps/checkout/service/business/methods_test.go
@@ -25,15 +25,30 @@ import (
 const testMethodsJSON = `[
   {"key":"mpesa","name":"M-PESA","route":"mpesa","prefixes":["254"],"currencies":["KES"]},
   {"key":"mtn_momo","name":"MTN MoMo","route":"mtn","prefixes":["256","260"],"currencies":["UGX","ZMW"]},
+  {"key":"pawapay","name":"Mobile Money","route":"pawapay","prefixes":[],"currencies":[]},
+  {"key":"card","name":"Card","route":"polar","prefixes":[],"currencies":[],"redirect":true}
+]`
+
+const testMethodsJSONNoRedirect = `[
+  {"key":"mpesa","name":"M-PESA","route":"mpesa","prefixes":["254"],"currencies":["KES"]},
+  {"key":"mtn_momo","name":"MTN MoMo","route":"mtn","prefixes":["256","260"],"currencies":["UGX","ZMW"]},
   {"key":"pawapay","name":"Mobile Money","route":"pawapay","prefixes":[],"currencies":[]}
 ]`
 
 func TestParseMethodRegistry(t *testing.T) {
 	reg, err := business.ParseMethodRegistry(testMethodsJSON)
 	require.NoError(t, err)
-	require.Len(t, reg.Methods, 3)
+	require.Len(t, reg.Methods, 4)
 	assert.Equal(t, "mpesa", reg.Methods[0].Key)
 	assert.Equal(t, "mtn", reg.Methods[1].Route)
+	// card method has redirect=true
+	cardMethod, ok := reg.Get("card")
+	require.True(t, ok)
+	assert.True(t, cardMethod.Redirect, "card method must have Redirect=true")
+	// non-redirect methods have Redirect=false
+	mpesa, ok := reg.Get("mpesa")
+	require.True(t, ok)
+	assert.False(t, mpesa.Redirect, "mpesa method must have Redirect=false")
 
 	_, err = business.ParseMethodRegistry("not json")
 	require.Error(t, err)
@@ -47,7 +62,7 @@ func TestAvailableMethods(t *testing.T) {
 	require.NoError(t, err)
 
 	all := reg.Available(nil)
-	assert.Len(t, all, 3)
+	assert.Len(t, all, 4)
 
 	restricted := reg.Available([]string{"mpesa", "unknown"})
 	require.Len(t, restricted, 1)
@@ -62,14 +77,19 @@ func TestGetMethod(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "MTN MoMo", m.Name)
 
-	_, ok = reg.Get("card")
+	cardMethod, ok := reg.Get("card")
+	require.True(t, ok, "card method must be found in registry")
+	assert.True(t, cardMethod.Redirect, "card must be a redirect method")
+
+	_, ok = reg.Get("stripe")
 	assert.False(t, ok)
 }
 
 func TestPreselect(t *testing.T) {
-	reg, err := business.ParseMethodRegistry(testMethodsJSON)
+	// Use non-redirect registry for the baseline tests to avoid changing existing behaviour.
+	regNoRedirect, err := business.ParseMethodRegistry(testMethodsJSONNoRedirect)
 	require.NoError(t, err)
-	methods := reg.Available(nil)
+	methods := regNoRedirect.Available(nil)
 
 	t.Run("clue wins", func(t *testing.T) {
 		m := business.Preselect(methods, "mtn_momo", "254712345678")
@@ -88,7 +108,37 @@ func TestPreselect(t *testing.T) {
 		assert.Equal(t, "mpesa", m.Key)
 	})
 	t.Run("unknown clue falls through to prefix", func(t *testing.T) {
-		m := business.Preselect(methods, "card", "260763456789")
+		m := business.Preselect(methods, "stripe", "260763456789")
 		assert.Equal(t, "mtn_momo", m.Key)
+	})
+}
+
+func TestPreselect_RedirectMethod(t *testing.T) {
+	reg, err := business.ParseMethodRegistry(testMethodsJSON)
+	require.NoError(t, err)
+	methods := reg.Available(nil)
+
+	t.Run("redirect method never selected by phone prefix", func(t *testing.T) {
+		// card has no prefixes, but even if a redirect method had prefixes it must not be
+		// matched by phone. Use the full methods list which includes the card (redirect) method.
+		// A 254-prefix phone should select mpesa, not card.
+		m := business.Preselect(methods, "", "254712345678")
+		assert.Equal(t, "mpesa", m.Key, "redirect method must not be selected by phone prefix")
+		assert.False(t, m.Redirect, "selected method must not be a redirect method")
+	})
+
+	t.Run("explicit clue selects redirect method", func(t *testing.T) {
+		m := business.Preselect(methods, "card", "254712345678")
+		assert.Equal(t, "card", m.Key, "explicit clue must select the redirect method")
+		assert.True(t, m.Redirect, "selected method must be the redirect method")
+	})
+
+	t.Run("redirect method as first fallback when no other match", func(t *testing.T) {
+		// Only redirect methods available — should still return first one.
+		redirectOnly := []business.Method{
+			{Key: "card", Name: "Card", Route: "polar", Redirect: true},
+		}
+		m := business.Preselect(redirectOnly, "", "")
+		assert.Equal(t, "card", m.Key, "redirect method returned as first-entry fallback")
 	})
 }

--- a/apps/checkout/service/handlers/render.go
+++ b/apps/checkout/service/handlers/render.go
@@ -127,6 +127,7 @@ var translations = map[string]map[string]string{
 		"bad_method":        "Choose a payment method",
 		"amount_required":   "Enter a valid amount",
 		"contact_required":  "Enter your phone number",
+		"redirect_hint":     "Taking you to secure payment…",
 	},
 	"fr": {
 		"pay_button":        "Payer",
@@ -147,6 +148,7 @@ var translations = map[string]map[string]string{
 		"bad_method":        "Choisissez un moyen de paiement",
 		"amount_required":   "Saisissez un montant valide",
 		"contact_required":  "Saisissez votre numéro de téléphone",
+		"redirect_hint":     "Redirection vers le paiement sécurisé…",
 	},
 }
 

--- a/apps/checkout/service/handlers/web.go
+++ b/apps/checkout/service/handlers/web.go
@@ -602,6 +602,17 @@ func (s *WebServer) HandleStatus(w http.ResponseWriter, r *http.Request) {
 		lang := pickLang(r, "")
 		payload["failure_reason"] = T(lang, "failed_title")
 	}
+	// Surface redirect URL for card/redirect payment methods.
+	// Only emit when session is still processing and the URL passes the safe-URL check
+	// (defense in depth — never hand the browser a javascript: URL even if the
+	// provider pipeline were compromised).
+	if session.Status == models.SessionStatusProcessing && session.Metadata != nil {
+		if redirectURL, ok := session.Metadata["_redirect_url"].(string); ok && redirectURL != "" {
+			if business.IsSafeReturnURL(redirectURL) {
+				payload["redirect_url"] = redirectURL
+			}
+		}
+	}
 	writeJSON(w, http.StatusOK, payload)
 }
 

--- a/apps/checkout/service/handlers/web_test.go
+++ b/apps/checkout/service/handlers/web_test.go
@@ -810,6 +810,85 @@ func TestRateLimiter_XFF_Buckets(t *testing.T) {
 	)
 }
 
+// 12b. HandleStatus for a processing session with _redirect_url in metadata → JSON includes redirect_url.
+func TestHandleStatus_ProcessingSession_IncludesRedirectURL(t *testing.T) {
+	h := newHarness(t)
+	s := &models.CheckoutSession{
+		Ref:       "sess-redirect-status",
+		Status:    models.SessionStatusProcessing,
+		PromptID:  "prompt-polar",
+		Currency:  "USD",
+		ExpiresAt: fixedNow().Add(30 * time.Minute),
+		Metadata: map[string]any{
+			"_redirect_url": "https://polar.sh/checkout/abc123",
+		},
+	}
+	h.sessionRepo.sessions["sess-redirect-status"] = s
+
+	req := httptest.NewRequest(http.MethodGet, "/c/sess-redirect-status/status", nil)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var payload map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
+	assert.Equal(t, "processing", payload["status"])
+	assert.Equal(t, "https://polar.sh/checkout/abc123", payload["redirect_url"])
+}
+
+// 12c. HandleStatus for a processing session with javascript: _redirect_url → redirect_url NOT emitted.
+func TestHandleStatus_ProcessingSession_JavascriptRedirectURL_NotEmitted(t *testing.T) {
+	h := newHarness(t)
+	s := &models.CheckoutSession{
+		Ref:       "sess-js-redirect",
+		Status:    models.SessionStatusProcessing,
+		PromptID:  "prompt-js",
+		Currency:  "USD",
+		ExpiresAt: fixedNow().Add(30 * time.Minute),
+		Metadata: map[string]any{
+			"_redirect_url": "javascript:alert(1)",
+		},
+	}
+	h.sessionRepo.sessions["sess-js-redirect"] = s
+
+	req := httptest.NewRequest(http.MethodGet, "/c/sess-js-redirect/status", nil)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
+	assert.Equal(t, "processing", payload["status"])
+	assert.Empty(t, payload["redirect_url"], "javascript: URL must never be surfaced")
+}
+
+// 12d. HandleStatus for a completed session with _redirect_url → redirect_url NOT emitted (only processing).
+func TestHandleStatus_CompletedSession_RedirectURL_NotEmitted(t *testing.T) {
+	h := newHarness(t)
+	s := &models.CheckoutSession{
+		Ref:    "sess-done-redirect",
+		Status: models.SessionStatusCompleted,
+		Metadata: map[string]any{
+			"_redirect_url": "https://polar.sh/checkout/done",
+		},
+	}
+	h.sessionRepo.sessions["sess-done-redirect"] = s
+
+	req := httptest.NewRequest(http.MethodGet, "/c/sess-done-redirect/status", nil)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
+	assert.Equal(t, "completed", payload["status"])
+	assert.Empty(t, payload["redirect_url"], "redirect_url must not be emitted for completed sessions")
+}
+
 // 13. Session with javascript: ReturnURL: done page must NOT include a meta-refresh
 // or any link/redirect target containing "javascript:".
 func TestHandlePage_CompletedSession_JavascriptReturnURL_NoRefresh(t *testing.T) {

--- a/apps/checkout/service/web/static/checkout.js
+++ b/apps/checkout/service/web/static/checkout.js
@@ -11,7 +11,10 @@
       fetch(pollURL)
         .then(function (res) { return res.json(); })
         .then(function (data) {
-          if (data.status === 'completed') {
+          if (data.redirect_url) {
+            clearInterval(intervalID);
+            window.location = data.redirect_url;
+          } else if (data.status === 'completed') {
             clearInterval(intervalID);
             var dest = returnURL || location.href;
             var sep = dest.indexOf('?') >= 0 ? '&' : '?';

--- a/apps/checkout/service/web/templates/confirm.html
+++ b/apps/checkout/service/web/templates/confirm.html
@@ -2,6 +2,7 @@
 
 <h2>{{t .Lang "confirm_title"}}</h2>
 <p class="hint">{{t .Lang "confirm_hint"}}</p>
+<p class="hint redirect-hint">{{t .Lang "redirect_hint"}}</p>
 <div class="spinner" aria-label="loading"></div>
 <a href="/c/{{.SessionRef}}" class="retry-link">{{t .Lang "retry"}}</a>
 


### PR DESCRIPTION
## Summary

Adds support for redirect-based payment methods to the hosted checkout page, enabling card payments via polar.sh's hosted checkout. Mobile-money methods are unchanged.

- Method registry gains a `redirect bool` flag; the default registry adds a `card` method routed to `polar`
- `Pay` skips payer/phone resolution for redirect methods (no `ErrContactRequired`)
- `RefreshStatus` captures the provider `checkout_url` from the prompt status extras, validates it with `IsSafeReturnURL` (blocks `javascript:`/cross-scheme), and stores it idempotently
- `/c/{ref}/status` emits `redirect_url` (defense-in-depth re-validated); `checkout.js` redirects the payer to the secure hosted page; confirm page shows a "taking you to secure payment" hint (EN/FR)
- Preselection never auto-picks a redirect method by phone prefix — only by explicit clue or as fallback

Part of the polar.sh card-billing + recurring-subscription work; the polar client recurring methods and billing's subscription mirror follow in companion PRs.