### PR TITLE
feat(polar): subscription lifecycle (get/cancel) and canceled webhooks

### DIFF
--- a/apps/integrations/polar/service/client/client.go
+++ b/apps/integrations/polar/service/client/client.go
@@ -182,6 +182,121 @@ func (c *polarClient) VerifyWebhookSignature(
 	return &event, nil
 }
 
+//nolint:nonamedreturns // named retErr captured by deferred metrics done callback
+func (c *polarClient) GetSubscription(
+	ctx context.Context,
+	creds *PolarCredentials,
+	subscriptionID string,
+) (_ *Subscription, retErr error) {
+	ctx, done := c.metrics.ObserveProviderCall(ctx, "get_subscription")
+	defer func() { done(retErr) }()
+	logger := util.Log(ctx).WithField("type", "polar.get_subscription")
+	defer logger.Release()
+
+	url := creds.BaseURL() + "/v1/subscriptions/" + subscriptionID
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create get subscription request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+creds.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("execute get subscription request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	logger.WithFields(map[string]any{
+		"status":          resp.StatusCode,
+		"subscription_id": subscriptionID,
+	}).Debug("get subscription response")
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get subscription failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var sub Subscription
+	if err = json.Unmarshal(respBody, &sub); err != nil {
+		return nil, fmt.Errorf("decode get subscription response: %w", err)
+	}
+
+	return &sub, nil
+}
+
+//nolint:nonamedreturns // named retErr captured by deferred metrics done callback
+func (c *polarClient) CancelSubscription(
+	ctx context.Context,
+	creds *PolarCredentials,
+	subscriptionID string,
+	atPeriodEnd bool,
+) (_ *Subscription, retErr error) {
+	ctx, done := c.metrics.ObserveProviderCall(ctx, "cancel_subscription")
+	defer func() { done(retErr) }()
+	logger := util.Log(ctx).WithField("type", "polar.cancel_subscription")
+	defer logger.Release()
+
+	var (
+		method string
+		url    string
+		body   []byte
+	)
+
+	if atPeriodEnd {
+		// PATCH /v1/subscriptions/{id} with cancel_at_period_end=true
+		method = http.MethodPatch
+		url = creds.BaseURL() + "/v1/subscriptions/" + subscriptionID
+		var marshalErr error
+		body, marshalErr = json.Marshal(map[string]any{"cancel_at_period_end": true})
+		if marshalErr != nil {
+			return nil, fmt.Errorf("marshal cancel subscription payload: %w", marshalErr)
+		}
+	} else {
+		// DELETE /v1/subscriptions/{id}/revoke for immediate cancellation
+		method = http.MethodDelete
+		url = creds.BaseURL() + "/v1/subscriptions/" + subscriptionID + "/revoke"
+	}
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create cancel subscription request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+creds.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("execute cancel subscription request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	logger.WithFields(map[string]any{
+		"status":          resp.StatusCode,
+		"subscription_id": subscriptionID,
+		"at_period_end":   atPeriodEnd,
+	}).Debug("cancel subscription response")
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cancel subscription failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var sub Subscription
+	if err = json.Unmarshal(respBody, &sub); err != nil {
+		return nil, fmt.Errorf("decode cancel subscription response: %w", err)
+	}
+
+	return &sub, nil
+}
+
 func parseTimestamp(ts string) (time.Time, error) {
 	// Standard Webhooks timestamp is Unix epoch seconds
 	var epoch int64

--- a/apps/integrations/polar/service/client/client_test.go
+++ b/apps/integrations/polar/service/client/client_test.go
@@ -1,0 +1,186 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/antinvestor/service-payments/apps/integrations/polar/service/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCreds returns PolarCredentials pointed at the given test server URL.
+// BaseURLOverride ensures the client does not contact the real polar API.
+func testCreds(serverURL string) *client.PolarCredentials {
+	return &client.PolarCredentials{
+		APIKey:          "test-api-key",
+		Environment:     "sandbox",
+		BaseURLOverride: serverURL,
+	}
+}
+
+// TestGetSubscription verifies GET /v1/subscriptions/{id} path, method, auth
+// header, and that the response is correctly decoded into a Subscription.
+func TestGetSubscription(t *testing.T) {
+	const subID = "sub_01abc"
+
+	responseBody := `{
+		"id": "sub_01abc",
+		"status": "active",
+		"product_id": "prod_xyz",
+		"customer_id": "cust_123",
+		"current_period_end": "2026-07-01T00:00:00Z",
+		"cancel_at_period_end": false,
+		"metadata": {"prompt_id": "p1", "tenant_id": "t1"}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/subscriptions/"+subID, r.URL.Path)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(responseBody))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	polarCli := client.NewClient()
+	sub, err := polarCli.GetSubscription(context.Background(), testCreds(server.URL), subID)
+
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	assert.Equal(t, "sub_01abc", sub.ID)
+	assert.Equal(t, "active", sub.Status)
+	assert.Equal(t, "prod_xyz", sub.ProductID)
+	assert.Equal(t, "cust_123", sub.CustomerID)
+	assert.Equal(t, "2026-07-01T00:00:00Z", sub.CurrentPeriodEnd)
+	assert.False(t, sub.CancelAtPeriodEnd)
+	assert.Equal(t, "t1", sub.Metadata["tenant_id"])
+}
+
+// TestGetSubscription_Error verifies that a non-200 response returns an error.
+func TestGetSubscription_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error": "not found"}`))
+	}))
+	defer server.Close()
+
+	polarCli := client.NewClient()
+	sub, err := polarCli.GetSubscription(context.Background(), testCreds(server.URL), "missing-id")
+
+	require.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "404")
+}
+
+// TestCancelSubscription_AtPeriodEnd verifies PATCH /v1/subscriptions/{id}
+// with cancel_at_period_end=true body is sent correctly.
+func TestCancelSubscription_AtPeriodEnd(t *testing.T) {
+	const subID = "sub_01abc"
+
+	responseBody := `{
+		"id": "sub_01abc",
+		"status": "active",
+		"product_id": "prod_xyz",
+		"customer_id": "cust_123",
+		"current_period_end": "2026-07-01T00:00:00Z",
+		"cancel_at_period_end": true,
+		"metadata": {}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v1/subscriptions/"+subID, r.URL.Path)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, true, payload["cancel_at_period_end"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(responseBody))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	polarCli := client.NewClient()
+	sub, err := polarCli.CancelSubscription(context.Background(), testCreds(server.URL), subID, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	assert.Equal(t, "sub_01abc", sub.ID)
+	assert.True(t, sub.CancelAtPeriodEnd)
+}
+
+// TestCancelSubscription_Immediate verifies DELETE /v1/subscriptions/{id}/revoke
+// is called for immediate cancellation.
+func TestCancelSubscription_Immediate(t *testing.T) {
+	const subID = "sub_01abc"
+
+	responseBody := `{
+		"id": "sub_01abc",
+		"status": "canceled",
+		"product_id": "prod_xyz",
+		"customer_id": "cust_123",
+		"current_period_end": "2026-06-13T00:00:00Z",
+		"cancel_at_period_end": false,
+		"metadata": {}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/v1/subscriptions/"+subID+"/revoke", r.URL.Path)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(responseBody))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	polarCli := client.NewClient()
+	sub, err := polarCli.CancelSubscription(context.Background(), testCreds(server.URL), subID, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	assert.Equal(t, "canceled", sub.Status)
+	assert.False(t, sub.CancelAtPeriodEnd)
+}
+
+// TestCancelSubscription_Error verifies that a non-200 response returns an error.
+func TestCancelSubscription_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"error": "already canceled"}`))
+	}))
+	defer server.Close()
+
+	polarCli := client.NewClient()
+	sub, err := polarCli.CancelSubscription(context.Background(), testCreds(server.URL), "sub_01abc", true)
+
+	require.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "422")
+}

--- a/apps/integrations/polar/service/client/interfaces.go
+++ b/apps/integrations/polar/service/client/interfaces.go
@@ -18,9 +18,28 @@ import "context"
 
 // PolarClient defines the interface for Polar.sh API operations.
 type PolarClient interface {
-	// CreateCheckout creates a Polar checkout session for requesting money
+	// CreateCheckout creates a Polar checkout session for requesting money.
+	// For subscription products the product id determines recurrence — Polar
+	// decides subscription vs one-time by the product; no extra checkout field
+	// is required from our side.
 	CreateCheckout(ctx context.Context, creds *PolarCredentials, req *CheckoutRequest) (*CheckoutResponse, error)
 
 	// VerifyWebhookSignature verifies a Polar webhook signature
 	VerifyWebhookSignature(payload []byte, headers map[string]string, webhookSecret string) (*WebhookEvent, error)
+
+	// GetSubscription fetches the current state of a Polar subscription by ID.
+	// Endpoint: GET /v1/subscriptions/{id}
+	GetSubscription(ctx context.Context, creds *PolarCredentials, subscriptionID string) (*Subscription, error)
+
+	// CancelSubscription cancels a Polar subscription.
+	// When atPeriodEnd is true the subscription is cancelled at the end of the
+	// current billing period (PATCH /v1/subscriptions/{id} with
+	// cancel_at_period_end=true); when false the subscription is revoked
+	// immediately (DELETE /v1/subscriptions/{id}/revoke).
+	CancelSubscription(
+		ctx context.Context,
+		creds *PolarCredentials,
+		subscriptionID string,
+		atPeriodEnd bool,
+	) (*Subscription, error)
 }

--- a/apps/integrations/polar/service/client/models.go
+++ b/apps/integrations/polar/service/client/models.go
@@ -20,10 +20,17 @@ type PolarCredentials struct {
 	WebhookSecret  string
 	OrganizationID string
 	Environment    string
+	// BaseURLOverride overrides the default base URL derived from Environment.
+	// Intended for testing only; leave empty in production.
+	BaseURLOverride string
 }
 
 // BaseURL returns the Polar API base URL based on environment.
+// If BaseURLOverride is set it takes precedence (useful in tests).
 func (c *PolarCredentials) BaseURL() string {
+	if c.BaseURLOverride != "" {
+		return c.BaseURLOverride
+	}
 	if c.Environment == "production" {
 		return "https://api.polar.sh"
 	}
@@ -63,4 +70,16 @@ type CheckoutResponse struct {
 type WebhookEvent struct {
 	Type string         `json:"type"`
 	Data map[string]any `json:"data"`
+}
+
+// Subscription represents a Polar subscription object returned by the API.
+// See https://docs.polar.sh/api-reference/subscriptions/get
+type Subscription struct {
+	ID                string         `json:"id"`
+	Status            string         `json:"status"`
+	ProductID         string         `json:"product_id"`
+	CustomerID        string         `json:"customer_id"`
+	CurrentPeriodEnd  string         `json:"current_period_end"`
+	CancelAtPeriodEnd bool           `json:"cancel_at_period_end"`
+	Metadata          map[string]any `json:"metadata"`
 }

--- a/apps/integrations/polar/service/handlers/webhooks.go
+++ b/apps/integrations/polar/service/handlers/webhooks.go
@@ -101,6 +101,12 @@ func (s *PolarWebhookServer) HandleWebhook(w http.ResponseWriter, r *http.Reques
 		statusErr = s.handleSubscriptionCreated(ctx, logger, event)
 	case "subscription.updated":
 		statusErr = s.handleSubscriptionUpdated(ctx, logger, event)
+	case "subscription.active":
+		statusErr = s.handleSubscriptionActive(ctx, logger, event)
+	case "subscription.canceled":
+		statusErr = s.handleSubscriptionCanceled(ctx, logger, event)
+	case "subscription.revoked":
+		statusErr = s.handleSubscriptionRevoked(ctx, logger, event)
 	default:
 		logger.Debug("unhandled event type, skipping")
 	}
@@ -260,6 +266,77 @@ func (s *PolarWebhookServer) handleSubscriptionUpdated(
 		"polar_event_type":    event.Type,
 		"subscription_id":     subID,
 		"subscription_status": subStatus,
+		"entity_type":         "prompt",
+	}
+
+	statusReq := &commonv1.StatusUpdateRequest{
+		Id:         promptID,
+		State:      state,
+		Status:     status,
+		ExternalId: subID,
+		Extras:     extras.ToProtoStruct(),
+	}
+
+	if _, err := s.paymentCli.StatusUpdate(ctx, connect.NewRequest(statusReq)); err != nil {
+		logger.WithError(err).Error("could not update payment status")
+		return err
+	}
+	return nil
+}
+
+func (s *PolarWebhookServer) handleSubscriptionActive(
+	ctx context.Context,
+	logger *util.LogEntry,
+	event *client.WebhookEvent,
+) error {
+	return s.updateSubscriptionStatus(ctx, logger, event, commonv1.STATE_ACTIVE, commonv1.STATUS_SUCCESSFUL)
+}
+
+func (s *PolarWebhookServer) handleSubscriptionCanceled(
+	ctx context.Context,
+	logger *util.LogEntry,
+	event *client.WebhookEvent,
+) error {
+	return s.updateSubscriptionStatus(ctx, logger, event, commonv1.STATE_INACTIVE, commonv1.STATUS_FAILED)
+}
+
+func (s *PolarWebhookServer) handleSubscriptionRevoked(
+	ctx context.Context,
+	logger *util.LogEntry,
+	event *client.WebhookEvent,
+) error {
+	return s.updateSubscriptionStatus(ctx, logger, event, commonv1.STATE_INACTIVE, commonv1.STATUS_FAILED)
+}
+
+// updateSubscriptionStatus is the shared implementation for subscription lifecycle
+// events (active, canceled, revoked). It extracts the subscription id, polar status,
+// and current_period_end from the event data and emits a StatusUpdate with the
+// supplied state and status codes. The extras carry polar_event_type,
+// subscription_id, subscription_status, current_period_end, and entity_type so
+// that billing can mirror the period state.
+func (s *PolarWebhookServer) updateSubscriptionStatus(
+	ctx context.Context,
+	logger *util.LogEntry,
+	event *client.WebhookEvent,
+	state commonv1.STATE,
+	status commonv1.STATUS,
+) error {
+	subID := getStringField(event.Data, "id")
+	subStatus := getStringField(event.Data, "status")
+	currentPeriodEnd := getStringField(event.Data, "current_period_end")
+	metadata := getMetadata(event.Data)
+	ctx = injectTenantContext(ctx, metadata)
+
+	promptID := metadata["prompt_id"]
+	if promptID == "" {
+		promptID = subID
+	}
+
+	extras := data.JSONMap{
+		"polar_event_type":    event.Type,
+		"subscription_id":     subID,
+		"subscription_status": subStatus,
+		"current_period_end":  currentPeriodEnd,
 		"entity_type":         "prompt",
 	}
 

--- a/apps/integrations/polar/service/handlers/webhooks_test.go
+++ b/apps/integrations/polar/service/handlers/webhooks_test.go
@@ -1,0 +1,366 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"buf.build/gen/go/antinvestor/payment/connectrpc/go/v1/paymentv1connect"
+	"connectrpc.com/connect"
+	"github.com/antinvestor/service-payments/apps/integrations/polar/config"
+	"github.com/antinvestor/service-payments/apps/integrations/polar/service/client"
+	"github.com/antinvestor/service-payments/apps/integrations/polar/service/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePaymentClient captures the most recent StatusUpdate call.
+type fakePaymentClient struct {
+	paymentv1connect.PaymentServiceClient
+	statusReq *commonv1.StatusUpdateRequest
+	err       error
+}
+
+func (f *fakePaymentClient) StatusUpdate(
+	_ context.Context,
+	req *connect.Request[commonv1.StatusUpdateRequest],
+) (*connect.Response[commonv1.StatusUpdateResponse], error) {
+	f.statusReq = req.Msg
+	if f.err != nil {
+		return nil, f.err
+	}
+	return connect.NewResponse(&commonv1.StatusUpdateResponse{}), nil
+}
+
+// fakePolarClient implements client.PolarClient. VerifyWebhookSignature
+// always succeeds, returning the pre-configured event without any HMAC
+// verification, so tests remain deterministic.
+type fakePolarClient struct {
+	client.PolarClient
+	event *client.WebhookEvent
+}
+
+func (f *fakePolarClient) VerifyWebhookSignature(
+	_ []byte,
+	_ map[string]string,
+	_ string,
+) (*client.WebhookEvent, error) {
+	return f.event, nil
+}
+
+func newWebhookServer(paymentCli *fakePaymentClient, event *client.WebhookEvent) *handlers.PolarWebhookServer {
+	polarCli := &fakePolarClient{event: event}
+	cfg := &config.PolarConfig{WebhookSecret: "whsec_" + base64.StdEncoding.EncodeToString([]byte("test-secret"))}
+	return handlers.NewPolarWebhookServer(paymentCli, polarCli, cfg)
+}
+
+func postWebhook(t *testing.T, srv *handlers.PolarWebhookServer) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/webhook/polar", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Webhook-Id", "msg_123")
+	req.Header.Set("Webhook-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	// Provide a dummy signature — fakePolarClient bypasses real verification.
+	req.Header.Set("Webhook-Signature", "v1,dummysig")
+	rr := httptest.NewRecorder()
+	srv.NewRouterV1().ServeHTTP(rr, req)
+	return rr
+}
+
+// buildSubEvent constructs a minimal WebhookEvent for the given type, embedding
+// the provided data fields. metadata is merged under the "metadata" key.
+func buildSubEvent(
+	eventType, subID, status, currentPeriodEnd string,
+	meta map[string]string,
+) *client.WebhookEvent {
+	metaAny := make(map[string]any, len(meta))
+	for k, v := range meta {
+		metaAny[k] = v
+	}
+	return &client.WebhookEvent{
+		Type: eventType,
+		Data: map[string]any{
+			"id":                   subID,
+			"status":               status,
+			"product_id":           "prod_xyz",
+			"customer_id":          "cust_123",
+			"current_period_end":   currentPeriodEnd,
+			"cancel_at_period_end": false,
+			"metadata":             metaAny,
+		},
+	}
+}
+
+// ─── subscription.created ─────────────────────────────────────────────────────
+
+func TestHandleSubscriptionCreated(t *testing.T) {
+	const (
+		subID    = "sub_01abc"
+		promptID = "prompt-001"
+	)
+	event := buildSubEvent("subscription.created", subID, "active", "2026-07-01T00:00:00Z", map[string]string{
+		"prompt_id":    promptID,
+		"tenant_id":    "t1",
+		"partition_id": "p1",
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, promptID, paymentCli.statusReq.GetId())
+	assert.Equal(t, subID, paymentCli.statusReq.GetExternalId())
+	assert.Equal(t, commonv1.STATUS_SUCCESSFUL, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_ACTIVE, paymentCli.statusReq.GetState())
+}
+
+// ─── subscription.updated ─────────────────────────────────────────────────────
+
+func TestHandleSubscriptionUpdated_Active(t *testing.T) {
+	event := buildSubEvent("subscription.updated", "sub_02", "active", "", map[string]string{
+		"prompt_id": "p2",
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, commonv1.STATUS_SUCCESSFUL, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_ACTIVE, paymentCli.statusReq.GetState())
+}
+
+func TestHandleSubscriptionUpdated_Canceled(t *testing.T) {
+	event := buildSubEvent("subscription.updated", "sub_02", "canceled", "", map[string]string{
+		"prompt_id": "p2",
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, commonv1.STATUS_FAILED, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_INACTIVE, paymentCli.statusReq.GetState())
+}
+
+// ─── subscription.active ──────────────────────────────────────────────────────
+
+func TestHandleSubscriptionActive(t *testing.T) {
+	const (
+		subID            = "sub_active_01"
+		promptID         = "prompt-active"
+		currentPeriodEnd = "2026-08-01T00:00:00Z"
+	)
+	event := buildSubEvent("subscription.active", subID, "active", currentPeriodEnd, map[string]string{
+		"prompt_id":    promptID,
+		"tenant_id":    "t2",
+		"partition_id": "p2",
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, promptID, paymentCli.statusReq.GetId())
+	assert.Equal(t, subID, paymentCli.statusReq.GetExternalId())
+	assert.Equal(t, commonv1.STATUS_SUCCESSFUL, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_ACTIVE, paymentCli.statusReq.GetState())
+
+	extras := paymentCli.statusReq.GetExtras().AsMap()
+	assert.Equal(t, "subscription.active", extras["polar_event_type"])
+	assert.Equal(t, subID, extras["subscription_id"])
+	assert.Equal(t, "active", extras["subscription_status"])
+	assert.Equal(t, currentPeriodEnd, extras["current_period_end"])
+	assert.Equal(t, "prompt", extras["entity_type"])
+}
+
+// ─── subscription.canceled ────────────────────────────────────────────────────
+
+func TestHandleSubscriptionCanceled(t *testing.T) {
+	const (
+		subID            = "sub_cancel_01"
+		promptID         = "prompt-cancel"
+		currentPeriodEnd = "2026-07-15T00:00:00Z"
+	)
+	event := buildSubEvent("subscription.canceled", subID, "canceled", currentPeriodEnd, map[string]string{
+		"prompt_id":    promptID,
+		"tenant_id":    "t3",
+		"partition_id": "p3",
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+
+	// ExternalId must be the polar subscription id (not prompt id)
+	assert.Equal(t, promptID, paymentCli.statusReq.GetId())
+	assert.Equal(t, subID, paymentCli.statusReq.GetExternalId())
+
+	// Terminal status
+	assert.Equal(t, commonv1.STATUS_FAILED, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_INACTIVE, paymentCli.statusReq.GetState())
+
+	// Extras carry polar status + current_period_end for billing mirror
+	extras := paymentCli.statusReq.GetExtras().AsMap()
+	assert.Equal(t, "subscription.canceled", extras["polar_event_type"])
+	assert.Equal(t, subID, extras["subscription_id"])
+	assert.Equal(t, "canceled", extras["subscription_status"])
+	assert.Equal(t, currentPeriodEnd, extras["current_period_end"])
+	assert.Equal(t, "prompt", extras["entity_type"])
+}
+
+// TestHandleSubscriptionCanceled_FallsBackToSubIDWhenNoPromptID verifies that
+// when metadata contains no prompt_id the polar subscription id is used as the
+// StatusUpdate id.
+func TestHandleSubscriptionCanceled_FallsBackToSubIDWhenNoPromptID(t *testing.T) {
+	const subID = "sub_cancel_02"
+	event := buildSubEvent("subscription.canceled", subID, "canceled", "", map[string]string{})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, subID, paymentCli.statusReq.GetId(), "id must fall back to sub id when prompt_id is absent")
+	assert.Equal(t, subID, paymentCli.statusReq.GetExternalId())
+}
+
+// ─── subscription.revoked ─────────────────────────────────────────────────────
+
+func TestHandleSubscriptionRevoked(t *testing.T) {
+	const (
+		subID    = "sub_revoke_01"
+		promptID = "prompt-revoke"
+	)
+	event := buildSubEvent("subscription.revoked", subID, "revoked", "2026-06-13T00:00:00Z", map[string]string{
+		"prompt_id": promptID,
+	})
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, promptID, paymentCli.statusReq.GetId())
+	assert.Equal(t, subID, paymentCli.statusReq.GetExternalId())
+	assert.Equal(t, commonv1.STATUS_FAILED, paymentCli.statusReq.GetStatus())
+	assert.Equal(t, commonv1.STATE_INACTIVE, paymentCli.statusReq.GetState())
+
+	extras := paymentCli.statusReq.GetExtras().AsMap()
+	assert.Equal(t, "subscription.revoked", extras["polar_event_type"])
+	assert.Equal(t, subID, extras["subscription_id"])
+	assert.Equal(t, "revoked", extras["subscription_status"])
+	assert.Equal(t, "prompt", extras["entity_type"])
+}
+
+// ─── checkout events (regression guard) ───────────────────────────────────────
+
+func TestHandleCheckoutCreated_Regression(t *testing.T) {
+	event := &client.WebhookEvent{
+		Type: "checkout.created",
+		Data: map[string]any{
+			"id":     "chk_001",
+			"status": "open",
+			"metadata": map[string]any{
+				"prompt_id": "prompt-checkout",
+			},
+		},
+	}
+
+	paymentCli := &fakePaymentClient{}
+	srv := newWebhookServer(paymentCli, event)
+	rr := postWebhook(t, srv)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, "prompt-checkout", paymentCli.statusReq.GetId())
+	assert.Equal(t, "chk_001", paymentCli.statusReq.GetExternalId())
+	assert.Equal(t, commonv1.STATUS_IN_PROCESS, paymentCli.statusReq.GetStatus())
+}
+
+// ─── HMAC signature verification (real client) ────────────────────────────────
+
+// TestHandleWebhook_InvalidSignature ensures that a tampered or missing
+// signature results in a 400 from the real (non-fake) polar client.
+func TestHandleWebhook_InvalidSignature(t *testing.T) {
+	realPolarCli := client.NewClient()
+	cfg := &config.PolarConfig{WebhookSecret: "whsec_" + base64.StdEncoding.EncodeToString([]byte("test-secret"))}
+	paymentCli := &fakePaymentClient{}
+	srv := handlers.NewPolarWebhookServer(paymentCli, realPolarCli, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/polar", strings.NewReader(`{}`))
+	req.Header.Set("Webhook-Id", "msg_123")
+	req.Header.Set("Webhook-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	req.Header.Set("Webhook-Signature", "v1,invalidsig")
+	rr := httptest.NewRecorder()
+	srv.NewRouterV1().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, paymentCli.statusReq)
+}
+
+// TestHandleWebhook_ValidHMAC ensures that a correctly-signed webhook is
+// accepted by the real polar client.
+func TestHandleWebhook_ValidHMAC(t *testing.T) {
+	rawSecret := []byte("test-secret-bytes")
+	webhookSecret := "whsec_" + base64.StdEncoding.EncodeToString(rawSecret)
+
+	msgID := "msg_hmac_test"
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	body := `{"type":"subscription.updated","data":{"id":"sub_hmac","status":"active","metadata":{"prompt_id":"p-hmac"}}}`
+
+	signedContent := msgID + "." + ts + "." + body
+	mac := hmac.New(sha256.New, rawSecret)
+	mac.Write([]byte(signedContent))
+	sig := "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	realPolarCli := client.NewClient()
+	cfg := &config.PolarConfig{WebhookSecret: webhookSecret}
+	paymentCli := &fakePaymentClient{}
+	srv := handlers.NewPolarWebhookServer(paymentCli, realPolarCli, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/polar", strings.NewReader(body))
+	req.Header.Set("Webhook-Id", msgID)
+	req.Header.Set("Webhook-Timestamp", ts)
+	req.Header.Set("Webhook-Signature", sig)
+	rr := httptest.NewRecorder()
+	srv.NewRouterV1().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, paymentCli.statusReq)
+	assert.Equal(t, "p-hmac", paymentCli.statusReq.GetId())
+}


### PR DESCRIPTION
## Summary

Extends the polar.sh integration from checkout-only to full subscription lifecycle, so polar can act as merchant of record for recurring card subscriptions.

- Client: `GetSubscription` (GET `/v1/subscriptions/{id}`), `CancelSubscription` (PATCH `cancel_at_period_end` for at-period-end, DELETE `/revoke` for immediate), `Subscription` model
- Webhooks: adds `subscription.active` (→ successful), `subscription.canceled` and `subscription.revoked` (→ failed/inactive), each carrying polar subscription id as ExternalId and `polar_event_type`/`subscription_status`/`current_period_end` in extras so billing can mirror period state
- Recurrence is determined by the polar product (no checkout-level recurring field — confirmed against polar's checkout API)

Companion to checkout redirect support (#171); billing's subscription state-mirror follows next.