### PR TITLE
feat(billing): polar-native recurring subscriptions with webhook state mirror

### DIFF
--- a/apps/billing/service/business/billing_workflow.go
+++ b/apps/billing/service/business/billing_workflow.go
@@ -26,6 +26,7 @@ import (
 	"github.com/antinvestor/service-payments/pkg/apperrors"
 	"github.com/pitabwire/frame/v2/data"
 	"github.com/pitabwire/frame/v2/workerpool"
+	"github.com/pitabwire/util"
 	"github.com/pitabwire/util/decimalx"
 )
 
@@ -117,6 +118,16 @@ func (w *billingWorkflow) RunBilling(
 		return nil, apperrors.ErrSubscriptionNotActive
 	}
 
+	// Guard: polar-collected plans skip internal invoice generation.
+	var plan *models.Plan
+	plan, err = w.catalogBusiness.GetPlan(ctx, sub.PlanID)
+	if err != nil {
+		return nil, fmt.Errorf("RunBilling: load plan for polar-check: %w", err)
+	}
+	if IsPolarCollected(plan) {
+		return w.completePolarRun(ctx, subscriptionID, sub, periodStart, periodEnd)
+	}
+
 	// Create idempotent billing run
 	idempotencyKey := fmt.Sprintf("%s:%s:%s",
 		subscriptionID,
@@ -158,6 +169,52 @@ func (w *billingWorkflow) RunBilling(
 	}
 
 	return run, nil
+}
+
+// completePolarRun creates a COMPLETED billing run for a polar-collected subscription
+// without generating any invoice. It is idempotent via the existing idempotency key.
+func (w *billingWorkflow) completePolarRun(
+	ctx context.Context,
+	subscriptionID string,
+	sub *models.Subscription,
+	periodStart, periodEnd time.Time,
+) (*models.BillingRun, error) {
+	util.Log(ctx).
+		WithField("subscription_id", subscriptionID).
+		WithField("plan_id", sub.PlanID).
+		Info("polar-collected subscription: skipping internal invoice generation")
+
+	idempotencyKey := fmt.Sprintf("%s:%s:%s",
+		subscriptionID,
+		periodStart.Format(time.RFC3339),
+		periodEnd.Format(time.RFC3339))
+
+	now := time.Now()
+	polarRun := &models.BillingRun{
+		SubscriptionID:   subscriptionID,
+		ProfileID:        sub.ProfileID,
+		CatalogVersionID: sub.CatalogVersionID,
+		State:            models.BillingRunStateCompleted,
+		PeriodStart:      periodStart,
+		PeriodEnd:        periodEnd,
+		StartedAt:        &now,
+		CompletedAt:      &now,
+		Idempotency:      idempotencyKey,
+	}
+	polarRun.GenID(ctx)
+
+	if createErr := w.runRepo.Create(ctx, polarRun); createErr != nil {
+		if data.ErrorIsDuplicateKey(createErr) {
+			existing, getErr := w.runRepo.GetByIdempotency(ctx, idempotencyKey)
+			if getErr != nil {
+				return nil, getErr
+			}
+			return existing, nil
+		}
+		return nil, createErr
+	}
+
+	return polarRun, nil
 }
 
 func (w *billingWorkflow) stepMetering(

--- a/apps/billing/service/business/catalog.go
+++ b/apps/billing/service/business/catalog.go
@@ -30,6 +30,7 @@ type CatalogBusiness interface {
 	GetCatalogVersion(ctx context.Context, id string) (*models.CatalogVersion, error)
 	GetEffectiveCatalog(ctx context.Context, catalogID string, at time.Time) (*models.CatalogVersion, error)
 	PublishCatalogVersion(ctx context.Context, id string, effectiveAt time.Time) (*models.CatalogVersion, error)
+	GetPlan(ctx context.Context, id string) (*models.Plan, error)
 	CreatePlan(ctx context.Context, plan *models.Plan) (*models.Plan, error)
 	CreateComponent(ctx context.Context, component *models.Component) (*models.Component, error)
 	CreateTier(ctx context.Context, tier *models.Tier) (*models.Tier, error)
@@ -126,6 +127,14 @@ func (b *catalogBusiness) PublishCatalogVersion(
 	}
 
 	return cv, nil
+}
+
+func (b *catalogBusiness) GetPlan(ctx context.Context, id string) (*models.Plan, error) {
+	if id == "" {
+		return nil, ErrPlanIDRequired
+	}
+
+	return b.planRepo.GetByID(ctx, id)
 }
 
 func (b *catalogBusiness) CreatePlan(ctx context.Context, plan *models.Plan) (*models.Plan, error) {

--- a/apps/billing/service/business/errors.go
+++ b/apps/billing/service/business/errors.go
@@ -59,4 +59,12 @@ var (
 
 	// Billing run errors.
 	ErrBillingRunIDRequired = errors.New("billing run ID is required")
+
+	// Polar subscription errors.
+	ErrPlanNotPolarCollected          = errors.New("plan does not have a polar product ID configured")
+	ErrPolarSubscriptionIDRequired    = errors.New("polar subscription ID is required")
+	ErrPolarSubscriptionNotFound      = errors.New("no billing subscription found for the given polar subscription")
+	ErrPolarMirrorProfileRequired     = errors.New("profile ID is required for polar subscription mirror")
+	ErrPolarMirrorPlanRequired        = errors.New("plan ID is required for polar subscription mirror")
+	ErrPolarMirrorPolarStatusRequired = errors.New("polar status is required for polar subscription mirror")
 )

--- a/apps/billing/service/business/polar_subscription.go
+++ b/apps/billing/service/business/polar_subscription.go
@@ -1,0 +1,363 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/antinvestor/service-payments/apps/billing/service/models"
+	"github.com/antinvestor/service-payments/apps/billing/service/observability"
+	"github.com/antinvestor/service-payments/apps/billing/service/repository"
+	"github.com/antinvestor/service-payments/pkg/apperrors"
+	"github.com/pitabwire/frame/v2/workerpool"
+	"github.com/pitabwire/util"
+)
+
+// Data map keys used by polar-collected subscriptions.
+const (
+	PolarDataKeyProductID         = "polarProductId"
+	PolarDataKeySubscriptionID    = "polarSubscriptionId"
+	PolarDataKeyStatus            = "polarStatus"
+	PolarDataKeyCurrentPeriodEnd  = "currentPeriodEnd"
+	PolarDataKeyCollectionMode    = "collectionMode"
+	PolarDataKeyCancelAtPeriodEnd = "cancelAtPeriodEnd"
+
+	polarCollectionModeValue = "polar"
+
+	// Polar subscription status values sent by the Polar webhook.
+	PolarStatusActive   = "active"
+	PolarStatusCanceled = "canceled"
+	PolarStatusRevoked  = "revoked"
+	PolarStatusPastDue  = "past_due"
+	PolarStatusUnpaid   = "unpaid"
+)
+
+// PolarProductID returns the polar product ID configured on the plan,
+// or "" when the plan has no polar product mapping.
+func PolarProductID(plan *models.Plan) string {
+	if plan == nil || plan.Data == nil {
+		return ""
+	}
+	v, _ := plan.Data[PolarDataKeyProductID].(string)
+	return v
+}
+
+// IsPolarCollected reports whether billing should delegate charge collection
+// for the plan to Polar. Plans with a non-empty polarProductId in their Data
+// map are polar-collected; all others use billing's internal invoice cycle.
+func IsPolarCollected(plan *models.Plan) bool {
+	return PolarProductID(plan) != ""
+}
+
+// StartPolarInput carries the parameters needed to initiate a polar-collected
+// subscription checkout.
+type StartPolarInput struct {
+	ProfileID        string
+	PlanID           string
+	CatalogVersionID string
+	Currency         string
+}
+
+// PolarSubscriptionStart is returned by StartPolarSubscription. It contains
+// the newly created billing Subscription (PENDING) and the Polar product ID
+// that the caller must use to initiate a Polar checkout session.
+type PolarSubscriptionStart struct {
+	Subscription   *models.Subscription
+	PolarProductID string
+}
+
+// MirrorInput carries the webhook-derived state that billing should mirror
+// onto the matching billing Subscription.
+type MirrorInput struct {
+	// PolarSubscriptionID is the identifier Polar assigned to the subscription.
+	// Used as the primary lookup key; falls back to ProfileID+PlanID if empty.
+	PolarSubscriptionID string
+	ProfileID           string
+	PlanID              string
+	// PolarStatus is the status string from the Polar webhook payload
+	// (e.g. "active", "canceled", "revoked", "past_due", "unpaid").
+	PolarStatus      string
+	CurrentPeriodEnd string // RFC 3339 timestamp or empty
+}
+
+// PolarSubscriptionBusiness manages the lifecycle of polar-collected subscriptions.
+// It is intentionally separate from SubscriptionBusiness to keep the polar-specific
+// logic isolated and the base interface unchanged.
+//
+// Transport note: Polar webhooks are emitted by the payment/polar service, NOT billing.
+// Billing has no inbound queue or event subscriber (see apps/billing/cmd/main.go — no
+// frame.WithRegisterSubscriber is wired). MirrorSubscriptionState is therefore exposed
+// as a business method; the payment/polar side MUST call it (via an RPC wrapper) when
+// it receives a Polar subscription.updated webhook.
+// TODO: wire an RPC handler on the billing service that calls MirrorSubscriptionState,
+// or add a billing subscriber once a shared queue topic is established.
+type PolarSubscriptionBusiness interface {
+	// StartPolarSubscription creates a PENDING billing Subscription linked to the
+	// plan's Polar product and returns the polar product ID for initiating checkout.
+	// Returns ErrPlanNotPolarCollected when the plan has no polarProductId.
+	StartPolarSubscription(ctx context.Context, plan *models.Plan, in StartPolarInput) (*PolarSubscriptionStart, error)
+
+	// MirrorSubscriptionState maps a Polar webhook payload to the billing Subscription
+	// state machine. It is idempotent: applying the same event twice yields the same result.
+	// Returns ErrPolarSubscriptionNotFound when no subscription can be matched.
+	MirrorSubscriptionState(ctx context.Context, in MirrorInput) (*models.Subscription, error)
+}
+
+type polarSubscriptionBusiness struct {
+	workMan workerpool.Manager
+	subRepo repository.SubscriptionRepository
+	obs     *observability.Metrics
+}
+
+// NewPolarSubscriptionBusiness constructs a PolarSubscriptionBusiness.
+func NewPolarSubscriptionBusiness(
+	workMan workerpool.Manager,
+	subRepo repository.SubscriptionRepository,
+) PolarSubscriptionBusiness {
+	return &polarSubscriptionBusiness{
+		workMan: workMan,
+		subRepo: subRepo,
+		obs:     observability.NewMetrics(),
+	}
+}
+
+// StartPolarSubscription validates the plan is polar-collected, creates a PENDING
+// subscription with polar metadata in Data, and returns the polar product ID.
+//
+//nolint:nonamedreturns // named err captured by deferred span-end closure
+func (b *polarSubscriptionBusiness) StartPolarSubscription(
+	ctx context.Context,
+	plan *models.Plan,
+	in StartPolarInput,
+) (result *PolarSubscriptionStart, err error) {
+	ctx, span := b.obs.StartSpan(ctx, "StartPolarSubscription")
+	defer func() {
+		b.obs.EndSpan(ctx, span, err)
+		if err == nil {
+			b.obs.RecordPolarSubscriptionStarted(ctx)
+		}
+	}()
+
+	if plan == nil {
+		return nil, ErrPlanIDRequired
+	}
+	polarProductID := PolarProductID(plan)
+	if polarProductID == "" {
+		return nil, ErrPlanNotPolarCollected
+	}
+	if in.ProfileID == "" {
+		return nil, ErrSubscriptionProfileRequired
+	}
+	if in.PlanID == "" {
+		return nil, ErrSubscriptionPlanRequired
+	}
+	if in.CatalogVersionID == "" {
+		return nil, ErrCatalogVersionRequired
+	}
+	if in.Currency == "" {
+		return nil, ErrSubscriptionCurrencyRequired
+	}
+
+	now := time.Now()
+	sub := &models.Subscription{
+		ProfileID:        in.ProfileID,
+		PlanID:           in.PlanID,
+		CatalogVersionID: in.CatalogVersionID,
+		State:            models.SubscriptionStatePending,
+		Currency:         in.Currency,
+		StartAt:          now,
+		BillingAnchor:    now,
+		Data: map[string]any{
+			PolarDataKeyCollectionMode: polarCollectionModeValue,
+			PolarDataKeyProductID:      polarProductID,
+		},
+	}
+	sub.GenID(ctx)
+
+	if err = b.subRepo.Create(ctx, sub); err != nil {
+		return nil, err
+	}
+
+	util.Log(ctx).
+		WithField("subscription_id", sub.GetID()).
+		WithField("polar_product_id", polarProductID).
+		Info("polar-collected subscription created in PENDING state")
+
+	return &PolarSubscriptionStart{
+		Subscription:   sub,
+		PolarProductID: polarProductID,
+	}, nil
+}
+
+// MirrorSubscriptionState applies a Polar webhook state to the matching billing Subscription.
+// Lookup order: polarSubscriptionId in Data → ProfileID+PlanID PENDING fallback.
+// Idempotent: re-applying the same status twice yields the same final state.
+//
+//nolint:nonamedreturns // named err captured by deferred closure
+func (b *polarSubscriptionBusiness) MirrorSubscriptionState(
+	ctx context.Context,
+	in MirrorInput,
+) (result *models.Subscription, err error) {
+	ctx, span := b.obs.StartSpan(ctx, "MirrorSubscriptionState")
+	defer func() {
+		b.obs.EndSpan(ctx, span, err)
+		if err == nil {
+			b.obs.RecordPolarSubscriptionMirrored(ctx)
+		}
+	}()
+
+	if in.ProfileID == "" {
+		return nil, ErrPolarMirrorProfileRequired
+	}
+	if in.PlanID == "" {
+		return nil, ErrPolarMirrorPlanRequired
+	}
+	if in.PolarStatus == "" {
+		return nil, ErrPolarMirrorPolarStatusRequired
+	}
+
+	// Locate the billing subscription: prefer an exact polarSubscriptionId match,
+	// fall back to the most recent PENDING record for this profile+plan.
+	sub, err := b.findSubscriptionForMirror(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stamp polar metadata unconditionally (idempotent).
+	if sub.Data == nil {
+		sub.Data = make(map[string]any)
+	}
+	if in.PolarSubscriptionID != "" {
+		sub.Data[PolarDataKeySubscriptionID] = in.PolarSubscriptionID
+	}
+	sub.Data[PolarDataKeyStatus] = in.PolarStatus
+	if in.CurrentPeriodEnd != "" {
+		sub.Data[PolarDataKeyCurrentPeriodEnd] = in.CurrentPeriodEnd
+	}
+
+	// Map polar status → billing state.
+	b.applyPolarStatus(ctx, sub, in)
+
+	_, err = b.subRepo.Update(ctx, sub)
+	if err != nil {
+		return nil, err
+	}
+
+	util.Log(ctx).
+		WithField("subscription_id", sub.GetID()).
+		WithField("polar_status", in.PolarStatus).
+		WithField("billing_state", sub.State).
+		Info("polar subscription state mirrored")
+
+	return sub, nil
+}
+
+// findSubscriptionForMirror resolves the billing subscription for the incoming mirror event.
+func (b *polarSubscriptionBusiness) findSubscriptionForMirror(
+	ctx context.Context,
+	in MirrorInput,
+) (*models.Subscription, error) {
+	// Primary lookup: exact polar subscription ID.
+	if in.PolarSubscriptionID != "" {
+		sub, err := b.subRepo.GetByPolarSubscriptionID(ctx, in.PolarSubscriptionID)
+		if err == nil {
+			return sub, nil
+		}
+		if !errors.Is(err, apperrors.ErrSubscriptionNotFound) {
+			return nil, err
+		}
+		// Not found by polar ID — fall through to profile+plan PENDING lookup.
+	}
+
+	// Fallback: find the most recent PENDING subscription for this profile+plan.
+	sub, err := b.subRepo.GetPendingByProfileAndPlan(ctx, in.ProfileID, in.PlanID)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrSubscriptionNotFound) {
+			return nil, ErrPolarSubscriptionNotFound
+		}
+		return nil, err
+	}
+
+	return sub, nil
+}
+
+// applyPolarStatus maps the Polar status to billing state and sets timestamps.
+// See design: active→ACTIVE; canceled with future period end→ACTIVE+cancelAtPeriodEnd;
+// canceled past period end→CANCELLED; revoked/past_due/unpaid→EXPIRED.
+// The sub is mutated in place.
+func (b *polarSubscriptionBusiness) applyPolarStatus(
+	ctx context.Context,
+	sub *models.Subscription,
+	in MirrorInput,
+) {
+	now := time.Now()
+
+	switch in.PolarStatus {
+	case PolarStatusActive:
+		// First activation: set StartAt.
+		if sub.State == models.SubscriptionStatePending {
+			sub.StartAt = now
+		}
+		sub.State = models.SubscriptionStateActive
+		// Update EndAt from current period end.
+		if in.CurrentPeriodEnd != "" {
+			t, parseErr := time.Parse(time.RFC3339, in.CurrentPeriodEnd)
+			if parseErr == nil {
+				sub.EndAt = &t
+			}
+		}
+		// Remove any lingering cancel-at-period-end flag on re-activation.
+		delete(sub.Data, PolarDataKeyCancelAtPeriodEnd)
+		b.obs.RecordPolarStateActive(ctx)
+
+	case PolarStatusCanceled:
+		// Polar "canceled" = will not renew but remains active until period end.
+		// If period end is in the future, keep ACTIVE and set the cancelAtPeriodEnd flag.
+		periodEnd, err := parsePeriodEnd(in.CurrentPeriodEnd)
+		if err == nil && periodEnd.After(now) {
+			sub.State = models.SubscriptionStateActive
+			sub.Data[PolarDataKeyCancelAtPeriodEnd] = "true"
+			t := periodEnd
+			sub.EndAt = &t
+		} else {
+			// Period already ended or no period info: hard cancel.
+			sub.State = models.SubscriptionStateCancelled
+			sub.CancelledAt = &now
+			b.obs.RecordPolarStateCancelled(ctx)
+		}
+
+	case PolarStatusRevoked, PolarStatusPastDue, PolarStatusUnpaid:
+		// Immediate termination.
+		sub.State = models.SubscriptionStateExpired
+		sub.CancelledAt = &now
+		b.obs.RecordPolarStateCancelled(ctx)
+
+	default:
+		// Unknown status — log and leave state unchanged to avoid incorrect transitions.
+		util.Log(ctx).
+			WithField("polar_status", in.PolarStatus).
+			Warn("unknown polar subscription status; billing state left unchanged")
+	}
+}
+
+// parsePeriodEnd parses an RFC 3339 period-end timestamp. Returns a zero time on error.
+func parsePeriodEnd(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, errors.New("empty period end")
+	}
+	return time.Parse(time.RFC3339, s)
+}

--- a/apps/billing/service/business/polar_subscription_test.go
+++ b/apps/billing/service/business/polar_subscription_test.go
@@ -1,0 +1,486 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/antinvestor/service-payments/apps/billing/service/business"
+	"github.com/antinvestor/service-payments/apps/billing/service/models"
+	billingTests "github.com/antinvestor/service-payments/apps/billing/tests"
+	"github.com/pitabwire/frame/v2/data"
+	"github.com/pitabwire/frame/v2/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// ---------------------------------------------------------------------------
+// Unit-level tests for pure helpers (no DB needed)
+// ---------------------------------------------------------------------------
+
+func TestPolarProductID(t *testing.T) {
+	tests := []struct {
+		name    string
+		plan    *models.Plan
+		wantID  string
+		wantPol bool
+	}{
+		{
+			name:    "nil plan",
+			plan:    nil,
+			wantID:  "",
+			wantPol: false,
+		},
+		{
+			name:    "plan with nil Data",
+			plan:    &models.Plan{},
+			wantID:  "",
+			wantPol: false,
+		},
+		{
+			name: "plan with empty Data",
+			plan: &models.Plan{
+				Data: data.JSONMap{},
+			},
+			wantID:  "",
+			wantPol: false,
+		},
+		{
+			name: "plan with non-string polarProductId",
+			plan: &models.Plan{
+				Data: data.JSONMap{"polarProductId": 12345},
+			},
+			wantID:  "",
+			wantPol: false,
+		},
+		{
+			name: "plan with empty string polarProductId",
+			plan: &models.Plan{
+				Data: data.JSONMap{"polarProductId": ""},
+			},
+			wantID:  "",
+			wantPol: false,
+		},
+		{
+			name: "plan with valid polarProductId",
+			plan: &models.Plan{
+				Data: data.JSONMap{"polarProductId": "prod_abc123"},
+			},
+			wantID:  "prod_abc123",
+			wantPol: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID := business.PolarProductID(tt.plan)
+			assert.Equal(t, tt.wantID, gotID, "PolarProductID")
+
+			gotPol := business.IsPolarCollected(tt.plan)
+			assert.Equal(t, tt.wantPol, gotPol, "IsPolarCollected")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration test suite (real PG via BaseTestSuite)
+// ---------------------------------------------------------------------------
+
+type PolarSubscriptionSuite struct {
+	billingTests.BaseTestSuite
+}
+
+func TestPolarSubscriptionSuite(t *testing.T) {
+	suite.Run(t, new(PolarSubscriptionSuite))
+}
+
+// makePolarPlan creates a minimal catalog version and a plan within the given context (which
+// must carry auth claims so RLS policies allow reads back).
+// If polarProductID is non-empty the plan's Data map carries "polarProductId".
+func makePolarPlan(
+	ctx context.Context,
+	t *testing.T,
+	resources *billingTests.ServiceResources,
+	polarProductID string,
+) (*models.CatalogVersion, *models.Plan) {
+	t.Helper()
+
+	cv := &models.CatalogVersion{
+		CatalogID: util.IDString(),
+		Version:   1,
+		Name:      "test catalog",
+		Currency:  "KES",
+	}
+	cv.GenID(ctx)
+	created, err := resources.CatalogBusiness.CreateCatalogVersion(ctx, cv)
+	require.NoError(t, err)
+
+	planData := data.JSONMap{}
+	if polarProductID != "" {
+		planData[business.PolarDataKeyProductID] = polarProductID
+	}
+
+	plan := &models.Plan{
+		CatalogVersionID: created.GetID(),
+		Name:             "test plan",
+		Data:             planData,
+	}
+	plan.GenID(ctx)
+	createdPlan, err := resources.CatalogBusiness.CreatePlan(ctx, plan)
+	require.NoError(t, err)
+
+	return created, createdPlan
+}
+
+// startPendingPolarSub creates a PENDING polar subscription via StartPolarSubscription.
+// ctx must carry auth claims so that the subscription is written with the correct tenant/partition.
+func startPendingPolarSub(
+	ctx context.Context,
+	t *testing.T,
+	resources *billingTests.ServiceResources,
+	profileID string,
+) (*models.Plan, *business.PolarSubscriptionStart) {
+	t.Helper()
+
+	_, plan := makePolarPlan(ctx, t, resources, "prod_mirror_test")
+	in := business.StartPolarInput{
+		ProfileID:        profileID,
+		PlanID:           plan.GetID(),
+		CatalogVersionID: plan.CatalogVersionID,
+		Currency:         "KES",
+	}
+	result, err := resources.PolarSubscriptionBusiness.StartPolarSubscription(ctx, plan, in)
+	require.NoError(t, err)
+	return plan, result
+}
+
+// ---------------------------------------------------------------------------
+// StartPolarSubscription tests
+// ---------------------------------------------------------------------------
+
+func (ts *PolarSubscriptionSuite) TestStartPolarSubscription_PolarPlan_CreatesPendingSubscription() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		_, plan := makePolarPlan(ctx, t, resources, "prod_polar_abc")
+
+		in := business.StartPolarInput{
+			ProfileID:        profileID,
+			PlanID:           plan.GetID(),
+			CatalogVersionID: plan.CatalogVersionID,
+			Currency:         "KES",
+		}
+		result, err := resources.PolarSubscriptionBusiness.StartPolarSubscription(ctx, plan, in)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.Subscription)
+		assert.Equal(t, "prod_polar_abc", result.PolarProductID)
+		assert.Equal(t, models.SubscriptionStatePending, result.Subscription.State)
+		assert.Equal(t, profileID, result.Subscription.ProfileID)
+		assert.Equal(t, plan.GetID(), result.Subscription.PlanID)
+
+		sub := result.Subscription
+		assert.Equal(t, "polar", sub.Data[business.PolarDataKeyCollectionMode])
+		assert.Equal(t, "prod_polar_abc", sub.Data[business.PolarDataKeyProductID])
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestStartPolarSubscription_NonPolarPlan_ReturnsError() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		_, plan := makePolarPlan(ctx, t, resources, "") // no polar product ID
+
+		in := business.StartPolarInput{
+			ProfileID:        profileID,
+			PlanID:           plan.GetID(),
+			CatalogVersionID: plan.CatalogVersionID,
+			Currency:         "KES",
+		}
+		result, err := resources.PolarSubscriptionBusiness.StartPolarSubscription(ctx, plan, in)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, business.ErrPlanNotPolarCollected)
+		assert.Nil(t, result)
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestStartPolarSubscription_NilPlan_ReturnsError() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		_, _, resources := ts.CreateService(t, dep)
+
+		in := business.StartPolarInput{ProfileID: util.IDString()}
+		result, err := resources.PolarSubscriptionBusiness.StartPolarSubscription(t.Context(), nil, in)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// MirrorSubscriptionState tests
+// ---------------------------------------------------------------------------
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_Active_TransitionsToActive() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		plan, start := startPendingPolarSub(ctx, t, resources, profileID)
+		polarSubID := "polarsub_" + util.IDString()
+		periodEnd := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+		in := business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    periodEnd,
+		}
+		sub, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, in)
+
+		require.NoError(t, err)
+		require.NotNil(t, sub)
+		assert.Equal(t, models.SubscriptionStateActive, sub.State)
+		assert.NotNil(t, sub.EndAt)
+		assert.Equal(t, polarSubID, sub.Data[business.PolarDataKeySubscriptionID])
+		assert.Equal(t, business.PolarStatusActive, sub.Data[business.PolarDataKeyStatus])
+		_ = start
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_CanceledFuturePeriodEnd_KeepsActiveWithFlag() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		plan, _ := startPendingPolarSub(ctx, t, resources, profileID)
+		polarSubID := "polarsub_" + util.IDString()
+
+		// First: activate.
+		futureEnd := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+		_, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    futureEnd,
+		})
+		require.NoError(t, err)
+
+		// Then: canceled but still within period.
+		sub, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusCanceled,
+			CurrentPeriodEnd:    futureEnd,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, sub)
+		assert.Equal(t, models.SubscriptionStateActive, sub.State,
+			"should remain ACTIVE when period end is in the future")
+		assert.Equal(t, "true", sub.Data[business.PolarDataKeyCancelAtPeriodEnd],
+			"cancelAtPeriodEnd flag must be set")
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_CanceledPastPeriodEnd_SetsCancelled() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		plan, _ := startPendingPolarSub(ctx, t, resources, profileID)
+		polarSubID := "polarsub_" + util.IDString()
+
+		// Activate with a past period end.
+		pastEnd := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+		_, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    pastEnd,
+		})
+		require.NoError(t, err)
+
+		// Canceled with period already ended.
+		sub, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusCanceled,
+			CurrentPeriodEnd:    pastEnd,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, models.SubscriptionStateCancelled, sub.State)
+		assert.NotNil(t, sub.CancelledAt)
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_Revoked_SetsExpired() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		plan, _ := startPendingPolarSub(ctx, t, resources, profileID)
+		polarSubID := "polarsub_" + util.IDString()
+
+		// Activate first.
+		_, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339),
+		})
+		require.NoError(t, err)
+
+		// Revoke.
+		sub, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusRevoked,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, models.SubscriptionStateExpired, sub.State)
+		assert.NotNil(t, sub.CancelledAt)
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_Idempotent() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		plan, _ := startPendingPolarSub(ctx, t, resources, profileID)
+		polarSubID := "polarsub_" + util.IDString()
+		periodEnd := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+		mirrorIn := business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    periodEnd,
+		}
+
+		// Apply twice.
+		sub1, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, mirrorIn)
+		require.NoError(t, err)
+
+		sub2, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, mirrorIn)
+		require.NoError(t, err)
+
+		assert.Equal(t, sub1.State, sub2.State, "state must be same on repeated apply")
+		assert.Equal(t, models.SubscriptionStateActive, sub2.State)
+	})
+}
+
+func (ts *PolarSubscriptionSuite) TestMirrorSubscriptionState_UnknownSubscription_ReturnsError() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		_, _, resources := ts.CreateService(t, dep)
+
+		in := business.MirrorInput{
+			PolarSubscriptionID: "polarsub_nonexistent",
+			ProfileID:           util.IDString(),
+			PlanID:              util.IDString(),
+			PolarStatus:         business.PolarStatusActive,
+		}
+		sub, err := resources.PolarSubscriptionBusiness.MirrorSubscriptionState(t.Context(), in)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, business.ErrPolarSubscriptionNotFound)
+		assert.Nil(t, sub)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RunBilling polar-collected guard
+// ---------------------------------------------------------------------------
+
+func (ts *PolarSubscriptionSuite) TestRunBilling_PolarCollectedPlan_NoInvoiceGenerated() {
+	ts.WithTestDependencies(ts.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, _, resources := ts.CreateService(t, dep)
+
+		profileID := util.IDString()
+		ctx = ts.WithAuthClaims(ctx, util.IDString(), util.IDString(), profileID)
+
+		// Create a polar-collected plan.
+		_, plan := makePolarPlan(ctx, t, resources, "prod_billing_guard_test")
+
+		// Start subscription and activate it via mirror so RunBilling finds it ACTIVE.
+		in := business.StartPolarInput{
+			ProfileID:        profileID,
+			PlanID:           plan.GetID(),
+			CatalogVersionID: plan.CatalogVersionID,
+			Currency:         "KES",
+		}
+		start, err := resources.PolarSubscriptionBusiness.StartPolarSubscription(ctx, plan, in)
+		require.NoError(t, err)
+
+		polarSubID := "polarsub_guard_" + util.IDString()
+		periodEnd := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+		_, err = resources.PolarSubscriptionBusiness.MirrorSubscriptionState(ctx, business.MirrorInput{
+			PolarSubscriptionID: polarSubID,
+			ProfileID:           profileID,
+			PlanID:              plan.GetID(),
+			PolarStatus:         business.PolarStatusActive,
+			CurrentPeriodEnd:    periodEnd,
+		})
+		require.NoError(t, err)
+
+		// RunBilling must complete immediately with no invoice.
+		now := time.Now()
+		run, err := resources.BillingWorkflow.RunBilling(
+			ctx,
+			start.Subscription.GetID(),
+			now.AddDate(0, -1, 0),
+			now,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, run)
+		assert.Equal(t, models.BillingRunStateCompleted, run.State,
+			"polar-collected run must be COMPLETED immediately")
+		assert.Empty(t, run.InvoiceID,
+			"no invoice must be generated for a polar-collected subscription")
+	})
+}

--- a/apps/billing/service/observability/metrics.go
+++ b/apps/billing/service/observability/metrics.go
@@ -51,6 +51,12 @@ type Metrics struct {
 	// Charge instruments.
 	chargesProcessed telemetry.Counter
 	chargeLatency    telemetry.Histogram
+
+	// Polar subscription instruments.
+	polarSubscriptionsStarted  telemetry.Counter
+	polarSubscriptionsMirrored telemetry.Counter
+	polarStateActive           telemetry.Counter
+	polarStateCancelled        telemetry.Counter
 }
 
 // NewMetrics creates and registers all OTel instruments for the billing service.
@@ -112,6 +118,23 @@ func NewMetrics() *Metrics {
 		chargeLatency: bm.Histogram(
 			pkgName+"/charge_latency_ms",
 			"Latency distribution of charge processing",
+		),
+
+		polarSubscriptionsStarted: bm.Counter(
+			pkgName+"/polar_subscriptions_started_total",
+			"Polar-collected subscription starts initiated",
+		),
+		polarSubscriptionsMirrored: bm.Counter(
+			pkgName+"/polar_subscriptions_mirrored_total",
+			"Polar subscription state mirror operations completed",
+		),
+		polarStateActive: bm.Counter(
+			pkgName+"/polar_state_active_total",
+			"Polar subscriptions transitioned to ACTIVE state",
+		),
+		polarStateCancelled: bm.Counter(
+			pkgName+"/polar_state_cancelled_total",
+			"Polar subscriptions transitioned to CANCELLED or EXPIRED state",
 		),
 	}
 }
@@ -203,4 +226,36 @@ func (m *Metrics) RecordChargeProcessed(ctx context.Context, elapsed time.Durati
 	}
 	m.chargesProcessed.Add(ctx, 1)
 	m.chargeLatency.Record(ctx, float64(elapsed.Milliseconds()))
+}
+
+// RecordPolarSubscriptionStarted counts a polar subscription start.
+func (m *Metrics) RecordPolarSubscriptionStarted(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.polarSubscriptionsStarted.Add(ctx, 1)
+}
+
+// RecordPolarSubscriptionMirrored counts a polar subscription mirror operation.
+func (m *Metrics) RecordPolarSubscriptionMirrored(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.polarSubscriptionsMirrored.Add(ctx, 1)
+}
+
+// RecordPolarStateActive counts a polar subscription transition to ACTIVE.
+func (m *Metrics) RecordPolarStateActive(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.polarStateActive.Add(ctx, 1)
+}
+
+// RecordPolarStateCancelled counts a polar subscription transition to CANCELLED or EXPIRED.
+func (m *Metrics) RecordPolarStateCancelled(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.polarStateCancelled.Add(ctx, 1)
 }

--- a/apps/billing/service/repository/subscription.go
+++ b/apps/billing/service/repository/subscription.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/antinvestor/service-payments/apps/billing/service/models"
 	"github.com/antinvestor/service-payments/pkg/apperrors"
+	"github.com/pitabwire/frame/v2/data"
 	"github.com/pitabwire/frame/v2/datastore"
 	"github.com/pitabwire/frame/v2/datastore/pool"
 	"github.com/pitabwire/frame/v2/workerpool"
@@ -29,6 +30,12 @@ type SubscriptionRepository interface {
 	datastore.BaseRepository[*models.Subscription]
 	SearchAsESQ(ctx context.Context, query string) (workerpool.JobResultPipe[[]*models.Subscription], error)
 	ListActiveByProfile(ctx context.Context, profileID string) ([]*models.Subscription, error)
+	// GetByPolarSubscriptionID finds a subscription by the polar subscription ID stored in its Data map.
+	// Returns apperrors.ErrSubscriptionNotFound when no match exists.
+	GetByPolarSubscriptionID(ctx context.Context, polarSubscriptionID string) (*models.Subscription, error)
+	// GetPendingByProfileAndPlan returns the first PENDING subscription for the given profile+plan combination.
+	// Returns apperrors.ErrSubscriptionNotFound when no match exists.
+	GetPendingByProfileAndPlan(ctx context.Context, profileID, planID string) (*models.Subscription, error)
 }
 
 type subscriptionRepository struct {
@@ -64,6 +71,51 @@ func (r *subscriptionRepository) ListActiveByProfile(
 	}
 
 	return list, nil
+}
+
+func (r *subscriptionRepository) GetByPolarSubscriptionID(
+	ctx context.Context,
+	polarSubscriptionID string,
+) (*models.Subscription, error) {
+	if polarSubscriptionID == "" {
+		return nil, apperrors.ErrUnspecifiedID
+	}
+
+	var sub models.Subscription
+	result := r.Pool().DB(ctx, true).
+		Where("data->>'polarSubscriptionId' = ?", polarSubscriptionID).
+		First(&sub)
+	if result.Error != nil {
+		if data.ErrorIsNoRows(result.Error) {
+			return nil, apperrors.ErrSubscriptionNotFound
+		}
+		return nil, apperrors.ErrSystemFailure.Override(result.Error)
+	}
+
+	return &sub, nil
+}
+
+func (r *subscriptionRepository) GetPendingByProfileAndPlan(
+	ctx context.Context,
+	profileID, planID string,
+) (*models.Subscription, error) {
+	if profileID == "" || planID == "" {
+		return nil, apperrors.ErrUnspecifiedID
+	}
+
+	var sub models.Subscription
+	result := r.Pool().DB(ctx, true).
+		Where("profile_id = ? AND plan_id = ? AND state = ?", profileID, planID, models.SubscriptionStatePending).
+		Order("created_at DESC").
+		First(&sub)
+	if result.Error != nil {
+		if data.ErrorIsNoRows(result.Error) {
+			return nil, apperrors.ErrSubscriptionNotFound
+		}
+		return nil, apperrors.ErrSystemFailure.Override(result.Error)
+	}
+
+	return &sub, nil
 }
 
 //nolint:dupl // SearchAsESQ follows a generic pattern that Go cannot DRY with generics + worker pools.

--- a/apps/billing/tests/base_testsuite.go
+++ b/apps/billing/tests/base_testsuite.go
@@ -46,16 +46,17 @@ const (
 )
 
 type ServiceResources struct {
-	CatalogBusiness      business.CatalogBusiness
-	SubscriptionBusiness business.SubscriptionBusiness
-	UsageIngestion       business.UsageIngestionBusiness
-	MeteringEngine       business.MeteringEngine
-	PricingEngine        *business.PricingEngine
-	DiscountEngine       business.DiscountEngine
-	CreditEngine         business.CreditEngine
-	InvoiceEngine        business.InvoiceEngine
-	BillingWorkflow      business.BillingWorkflow
-	LedgerIntegration    business.LedgerIntegration
+	CatalogBusiness           business.CatalogBusiness
+	SubscriptionBusiness      business.SubscriptionBusiness
+	PolarSubscriptionBusiness business.PolarSubscriptionBusiness
+	UsageIngestion            business.UsageIngestionBusiness
+	MeteringEngine            business.MeteringEngine
+	PricingEngine             *business.PricingEngine
+	DiscountEngine            business.DiscountEngine
+	CreditEngine              business.CreditEngine
+	InvoiceEngine             business.InvoiceEngine
+	BillingWorkflow           business.BillingWorkflow
+	LedgerIntegration         business.LedgerIntegration
 
 	// Repositories for direct access in tests
 	ComponentRepo  repository.ComponentRepository
@@ -161,6 +162,7 @@ func (bs *BaseTestSuite) CreateService(
 	// Business layers
 	catalogBus := business.NewCatalogBusiness(workMan, catalogVersionRepo, planRepo, componentRepo, tierRepo)
 	subscriptionBus := business.NewSubscriptionBusiness(workMan, subscriptionRepo)
+	polarSubBus := business.NewPolarSubscriptionBusiness(workMan, subscriptionRepo)
 	usageIngestionBus := business.NewUsageIngestionBusiness(workMan, usageEventRepo)
 	meteringEng := business.NewMeteringEngine(workMan, usageEventRepo, meteredUsageRepo)
 	pricingEng := business.NewPricingEngine()
@@ -173,20 +175,21 @@ func (bs *BaseTestSuite) CreateService(
 		meteringEng, pricingEng, discountEng, creditEng, invoiceEng, ledgerInteg, nil)
 
 	resources := &ServiceResources{
-		CatalogBusiness:      catalogBus,
-		SubscriptionBusiness: subscriptionBus,
-		UsageIngestion:       usageIngestionBus,
-		MeteringEngine:       meteringEng,
-		PricingEngine:        pricingEng,
-		DiscountEngine:       discountEng,
-		CreditEngine:         creditEng,
-		InvoiceEngine:        invoiceEng,
-		BillingWorkflow:      billingWorkflow,
-		LedgerIntegration:    ledgerInteg,
-		ComponentRepo:        componentRepo,
-		PlanRepo:             planRepo,
-		BillingRunRepo:       billingRunRepo,
-		InvoiceRepo:          invoiceRepo,
+		CatalogBusiness:           catalogBus,
+		SubscriptionBusiness:      subscriptionBus,
+		PolarSubscriptionBusiness: polarSubBus,
+		UsageIngestion:            usageIngestionBus,
+		MeteringEngine:            meteringEng,
+		PricingEngine:             pricingEng,
+		DiscountEngine:            discountEng,
+		CreditEngine:              creditEng,
+		InvoiceEngine:             invoiceEng,
+		BillingWorkflow:           billingWorkflow,
+		LedgerIntegration:         ledgerInteg,
+		ComponentRepo:             componentRepo,
+		PlanRepo:                  planRepo,
+		BillingRunRepo:            billingRunRepo,
+		InvoiceRepo:               invoiceRepo,
 	}
 
 	// Run both ledger and billing migrations

--- a/apps/integrations/polar/service/client/client.go
+++ b/apps/integrations/polar/service/client/client.go
@@ -205,7 +205,7 @@ func (c *polarClient) GetSubscription(
 	if err != nil {
 		return nil, fmt.Errorf("execute get subscription request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	logger.WithFields(map[string]any{
@@ -275,7 +275,7 @@ func (c *polarClient) CancelSubscription(
 	if err != nil {
 		return nil, fmt.Errorf("execute cancel subscription request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	logger.WithFields(map[string]any{


### PR DESCRIPTION
## Summary

Billing owns entitlement state but mirrors collection state from polar for card subscriptions (polar = merchant of record). Plan→polar-product mapping lives in the Plan's `Data["polarProductId"]`; plans without it keep the existing invoice+checkout cycle unchanged.

- `PolarProductID`/`IsPolarCollected` plan helpers
- `StartPolarSubscription`: validates the plan is polar-collected, creates a PENDING billing Subscription with `Data{collectionMode:"polar", polarProductId}`, returns the product id for the caller to open a polar checkout
- `MirrorSubscriptionState`: idempotent webhook mirror — looks up by `polarSubscriptionId` (JSONB) then profile+plan PENDING; maps polar status → billing state (active→ACTIVE+period end; canceled-at-period-end keeps ACTIVE with a `cancelAtPeriodEnd` flag until the period lapses; revoked/unpaid→EXPIRED)
- `RunBilling` guard: polar-collected subscriptions generate **no** internal invoice — the run completes immediately (polar charges renewals)
- Repo: `GetByPolarSubscriptionID`, `GetPendingByProfileAndPlan`; observability counters; tests on the real Postgres suite covering every mirror path + the no-invoice guard

## Transport follow-up (flagged, not hidden)

Billing has no inbound queue, and polar's subscription webhooks today emit to the **payment** service. Routing them into `MirrorSubscriptionState` needs a billing RPC (`MirrorSubscriptionState`/`StartPolarSubscription`), which requires the billing proto to round-trip through BSR (publish on release → dep bump → handler) — the same multi-step constraint as the `CollectInvoicePayment` RPC. The business logic is complete and tested; the RPC + polar→billing forwarding is the next PR once the proto publishes.

Companions: #171 (checkout redirect), #172 (polar subscription client).