### PR TITLE
deps: frame/v2 v2.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/moby/moby/api v1.55.0
-	github.com/pitabwire/frame/v2 v2.0.6
+	github.com/pitabwire/frame/v2 v2.0.7
 	github.com/pitabwire/util v0.9.1
 	github.com/pitabwire/util/decimalx v0.7.2
 	github.com/pitabwire/util/moneyx v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.6 h1:r4va8c+JQUSrKzIhHOKvdHvFfrJkLspx4CxAZtlHtyc=
-github.com/pitabwire/frame/v2 v2.0.6/go.mod h1:5rXjYOOGQPZmclphrBmOrKfoTWU0Gp+po/ldkJ0E7Xk=
+github.com/pitabwire/frame/v2 v2.0.7 h1:D26XomLXRR9ugI4tynBp/oRt5SsRlHsDLfLlJE3eQQU=
+github.com/pitabwire/frame/v2 v2.0.7/go.mod h1:al6xUWpP9myFR116c+IkA6JfCDUOE7kYOUGMCcfqnXg=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
Bump to frame/v2@v2.0.7 for tenancy session-binding hardening.

- Missing claims: no error, no filter
- Claims set: enforce
- Skip: bypass