### PR TITLE
fix(proto): currency string.len for buf lint

### DIFF
--- a/proto/billing/collection/v1/collection.proto
+++ b/proto/billing/collection/v1/collection.proto
@@ -65,10 +65,7 @@ message StartSubscriptionRequest {
   string profile_id = 1 [(buf.validate.field).string.min_len = 1];
   string plan_id = 2 [(buf.validate.field).string.min_len = 1];
   string catalog_version_id = 3 [(buf.validate.field).string.min_len = 1];
-  string currency = 4 [
-    (buf.validate.field).string.min_len = 3,
-    (buf.validate.field).string.max_len = 3
-  ];
+  string currency = 4 [(buf.validate.field).string.len = 3];
   // Optional override for the post-payment browser return URL.
   string return_url = 5 [
     (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,


### PR DESCRIPTION
Satisfy buf STANDARD lint: fixed-length currency fields.