### PR TITLE
fix(deps): bump frame/v2 to v2.0.15 for Cloud Run Keto TLS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/moby/moby/api v1.55.0
-	github.com/pitabwire/frame/v2 v2.0.14
+	github.com/pitabwire/frame/v2 v2.0.15
 	github.com/pitabwire/util v0.9.1
 	github.com/pitabwire/util/decimalx v0.7.2
 	github.com/pitabwire/util/moneyx v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.14 h1:U893N6avDJ4P24nycmsmNIRprUSURf3OKwPghxdLPQk=
-github.com/pitabwire/frame/v2 v2.0.14/go.mod h1:RqLpEfKx7nQdSdzUo6yZ64xw36MZscp12VreLBX2p8E=
+github.com/pitabwire/frame/v2 v2.0.15 h1:XtpKRL7Qf/KXAsFG7caVweHF8iTCdDT/nv/u04E5uvQ=
+github.com/pitabwire/frame/v2 v2.0.15/go.mod h1:32j4Jr6Soom38QkLy67oGxf1F+jEj0wE0hdUkzMJDOk=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- Bump `github.com/pitabwire/frame/v2` to **v2.0.15**
- Frame authorizer uses TLS + Google ID token for IAM-authenticated Keto gRPC on Cloud Run

## Test plan
- [ ] CI green
- [ ] Release + ship after merge
