### PR TITLE
fix(payments): retry paymentStatus.update on StatusUpdate failure

### DIFF
--- a/apps/checkout/service/business/checkout.go
+++ b/apps/checkout/service/business/checkout.go
@@ -1244,33 +1244,6 @@ func prefillHasContacts(prefill map[string]any) bool {
 	return ok && len(list) > 0
 }
 
-// firstPrefillContact returns the first MSISDN contact from session prefill.
-func (b *CheckoutBusiness) firstPrefillContact(session *models.CheckoutSession) (msisdn, contactID string) {
-	if session.Prefill == nil {
-		return "", ""
-	}
-	contactsRaw, ok := session.Prefill["contacts"]
-	if !ok {
-		return "", ""
-	}
-	contacts, ok := contactsRaw.([]any)
-	if !ok {
-		return "", ""
-	}
-	for _, raw := range contacts {
-		c, isMap := raw.(map[string]any)
-		if !isMap {
-			continue
-		}
-		phone, _ := c["msisdn"].(string)
-		cid, _ := c["contactId"].(string)
-		if strings.TrimSpace(phone) != "" {
-			return strings.TrimSpace(phone), cid
-		}
-	}
-	return "", ""
-}
-
 // findMsisdnFromPrefill looks up a msisdn for contactID in session prefill contacts.
 func (b *CheckoutBusiness) findMsisdnFromPrefill(
 	session *models.CheckoutSession,

--- a/apps/checkout/service/handlers/web.go
+++ b/apps/checkout/service/handlers/web.go
@@ -314,9 +314,10 @@ func extractContacts(prefill map[string]any, clueContactID string) (
 			msisdn = detail
 		}
 		masked := detail
-		if kind == "phone" {
+		switch kind {
+		case "phone":
 			masked = MaskMsisdn(msisdn)
-		} else if kind == "email" {
+		case "email":
 			masked = maskEmail(detail)
 		}
 		isSel := preferred || (clueContactID != "" && cid == clueContactID)

--- a/pkg/events/status_update.go
+++ b/pkg/events/status_update.go
@@ -74,8 +74,11 @@ func (e *PaymentStatusUpdate) Execute(ctx context.Context, payload any) error {
 
 	_, err := e.PaymentCli.StatusUpdate(ctx, connect.NewRequest(statusUpdateRequest))
 	if err != nil {
-		logger.WithError(err).Warn("could not update status")
-		return nil
+		// Return the error so queue delivery retries. Swallowing it left
+		// checkout sessions stuck in "processing" after provider success
+		// (e.g. Flutterwave charged, StatusUpdate denied on missing ReBAC).
+		logger.WithError(err).Error("could not update status")
+		return err
 	}
 
 	logger.Debug("event handler completed successfully")

--- a/pkg/events/status_update_test.go
+++ b/pkg/events/status_update_test.go
@@ -1,0 +1,101 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"buf.build/gen/go/antinvestor/payment/connectrpc/go/v1/paymentv1connect"
+	paymentv1 "buf.build/gen/go/antinvestor/payment/protocolbuffers/go/v1"
+	"connectrpc.com/connect"
+	"github.com/antinvestor/service-payments/pkg/events"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time check: stub implements the client used by PaymentStatusUpdate.
+var _ paymentv1connect.PaymentServiceClient = (*stubPaymentClient)(nil)
+
+type stubPaymentClient struct {
+	statusUpdateErr error
+	calls           int
+}
+
+func (s *stubPaymentClient) StatusUpdate(
+	_ context.Context,
+	_ *connect.Request[commonv1.StatusUpdateRequest],
+) (*connect.Response[commonv1.StatusUpdateResponse], error) {
+	s.calls++
+	if s.statusUpdateErr != nil {
+		return nil, s.statusUpdateErr
+	}
+	return connect.NewResponse(&commonv1.StatusUpdateResponse{
+		Data: &commonv1.StatusResponse{Id: "prompt-1", Status: commonv1.STATUS_SUCCESSFUL},
+	}), nil
+}
+
+func (s *stubPaymentClient) Send(context.Context, *connect.Request[paymentv1.SendRequest]) (*connect.Response[paymentv1.SendResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) Receive(context.Context, *connect.Request[paymentv1.ReceiveRequest]) (*connect.Response[paymentv1.ReceiveResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) InitiatePrompt(context.Context, *connect.Request[paymentv1.InitiatePromptRequest]) (*connect.Response[paymentv1.InitiatePromptResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) CreatePaymentLink(context.Context, *connect.Request[paymentv1.CreatePaymentLinkRequest]) (*connect.Response[paymentv1.CreatePaymentLinkResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) Status(context.Context, *connect.Request[commonv1.StatusRequest]) (*connect.Response[commonv1.StatusResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) Release(context.Context, *connect.Request[paymentv1.ReleaseRequest]) (*connect.Response[paymentv1.ReleaseResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) Search(context.Context, *connect.Request[commonv1.SearchRequest]) (*connect.ServerStreamForClient[paymentv1.SearchResponse], error) {
+	panic("unexpected")
+}
+func (s *stubPaymentClient) Reconcile(context.Context, *connect.Request[paymentv1.ReconcileRequest]) (*connect.Response[paymentv1.ReconcileResponse], error) {
+	panic("unexpected")
+}
+
+func TestPaymentStatusUpdate_PropagatesStatusUpdateError(t *testing.T) {
+	t.Parallel()
+	cli := &stubPaymentClient{statusUpdateErr: errors.New("permission_denied: payment_status_update")}
+	h := events.NewPaymentStatusUpdate(context.Background(), cli)
+
+	err := h.Execute(context.Background(), &commonv1.StatusUpdateRequest{
+		Id:     "prompt-1",
+		Status: commonv1.STATUS_SUCCESSFUL,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission_denied")
+	require.Equal(t, 1, cli.calls)
+}
+
+func TestPaymentStatusUpdate_Succeeds(t *testing.T) {
+	t.Parallel()
+	cli := &stubPaymentClient{}
+	h := events.NewPaymentStatusUpdate(context.Background(), cli)
+
+	err := h.Execute(context.Background(), &commonv1.StatusUpdateRequest{
+		Id:     "prompt-1",
+		Status: commonv1.STATUS_SUCCESSFUL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, cli.calls)
+}


### PR DESCRIPTION
## Summary
- `PaymentStatusUpdate` now returns StatusUpdate errors instead of swallowing them.
- Adds unit tests for success and permission-denied paths.

## Why
Swallowing the error acked the queue message after Flutterwave charged successfully, so checkout never left **processing** when ReBAC denied the write-back. Propagating the error allows delivery retries once authz is fixed.